### PR TITLE
Add rollingback to worker tasks

### DIFF
--- a/geoapi/services/notifications.py
+++ b/geoapi/services/notifications.py
@@ -7,6 +7,7 @@ from geoapi.log import logging
 
 logger = logging.getLogger(__file__)
 
+
 class NotificationsService:
 
     @staticmethod
@@ -28,19 +29,18 @@ class NotificationsService:
         return q.order_by(Notification.created.desc()) \
                 .limit(100).all()
 
-
     @staticmethod
     def create(user: User, status: AnyStr, message: AnyStr) -> Notification:
+        note = Notification(
+            username=user.username,
+            tenant_id=user.tenant_id,
+            status=status,
+            message=message
+        )
         try:
-            note = Notification(
-                username=user.username,
-                tenant_id=user.tenant_id,
-                status=status,
-                message=message
-            )
             db_session.add(note)
             db_session.commit()
             return note
-        except:
+        except Exception:
             db_session.rollback()
             raise

--- a/geoapi/services/notifications.py
+++ b/geoapi/services/notifications.py
@@ -31,21 +31,16 @@ class NotificationsService:
 
     @staticmethod
     def create(user: User, status: AnyStr, message: AnyStr) -> Notification:
-        note = Notification(
-            username=user.username,
-            tenant_id=user.tenant_id,
-            status=status,
-            message=message
-        )
-        db_session.add(note)
-        db_session.commit()
-        return note
-
-
-    @staticmethod
-    def create_with_rollback(user: User, status: AnyStr, message: AnyStr) -> Notification:
         try:
-            NotificationsService.create(user, status, message)
+            note = Notification(
+                username=user.username,
+                tenant_id=user.tenant_id,
+                status=status,
+                message=message
+            )
+            db_session.add(note)
+            db_session.commit()
+            return note
         except:
             db_session.rollback()
             raise

--- a/geoapi/services/notifications.py
+++ b/geoapi/services/notifications.py
@@ -40,3 +40,12 @@ class NotificationsService:
         db_session.add(note)
         db_session.commit()
         return note
+
+
+    @staticmethod
+    def create_with_rollback(user: User, status: AnyStr, message: AnyStr) -> Notification:
+        try:
+            NotificationsService.create(user, status, message)
+        except:
+            db_session.rollback()
+            raise

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -37,8 +37,23 @@ def import_file_from_agave(userId: int, systemId: str, path: str, projectId: int
         NotificationsService.create(user, "success", "Imported {f}".format(f=path))
         tmpFile.close()
     except Exception as e:
+        db_session.rollback()
         logger.error("Could not import file from agave: {} :: {}".format(systemId, path), e)
         NotificationsService.create(user, "error", "Error importing {f}".format(f=path))
+
+
+def _update_point_cloud_task(pointCloudId: int, description:str = None, status:str = None):
+    task = pointcloud.PointCloudService.get(pointCloudId).task
+    if description is not None:
+        task.description = description
+    if status is not None:
+        task.status = status
+    try:
+        db_session.add(task)
+        db_session.commit()
+    except:
+        db_session.rollback()
+        raise
 
 
 @app.task(rate_limit="1/s")
@@ -59,10 +74,10 @@ def import_point_clouds_from_agave(userId: int, files, pointCloudId: int):
     new_asset_files = []
     failed_message = None
     for file in files:
-        task.description = "Importing file ({}/{})".format(len(new_asset_files) + 1, len(files))
-        db_session.add(task)
-        db_session.commit()
-        NotificationsService.create(user, "success", task.description)
+        _update_point_cloud_task(pointCloudId,
+                                 description="Importing file ({}/{})".format(len(new_asset_files) + 1, len(files)))
+
+        NotificationsService.create_with_rollback(user, "success", task.description)
 
         system_id = file["system"]
         path = file["path"]
@@ -90,39 +105,40 @@ def import_point_clouds_from_agave(userId: int, files, pointCloudId: int):
             failed_message = 'Unknown error importing {}:{}'.format(system_id, path)
 
         if failed_message:
-            task.status = "FAILED"
-            task.description = failed_message
-            db_session.add(task)
-            db_session.commit()
-            NotificationsService.create(user, "error", failed_message)
             for file_path in new_asset_files:
-                print("removing {}!!!!!!!".format(file_path))
+                logger.error("removing {}!!!!!!!".format(file_path))
                 os.remove(file_path)
+            _update_point_cloud_task(pointCloudId, description=failed_message, status="FAILED")
+            NotificationsService.create_with_rollback(user, "error", failed_message)
             return
 
-    task.status = "RUNNING"
-    task.description = "Running potree converter"
-    point_cloud.files_info = json.dumps(get_point_cloud_info(pointCloudId));
+    _update_point_cloud_task(pointCloudId, description="Running potree converter", status="RUNNING")
 
-    db_session.add(point_cloud)
-    db_session.add(task)
-    db_session.commit()
-    NotificationsService.create(user,
-                                "success",
-                                "Running potree converter (for point cloud {}).".format(pointCloudId))
+    point_cloud.files_info = json.dumps(get_point_cloud_info(pointCloudId));
+    try:
+        db_session.add(point_cloud)
+        db_session.add(task)
+        db_session.commit()
+    except:
+        db_session.rollback()
+        raise
+    NotificationsService.create_with_rollback(user,
+                                              "success",
+                                              "Running potree converter (for point cloud {}).".format(pointCloudId))
 
     try:
         convert_to_potree.apply(args=[pointCloudId], task_id=celery_task_id, throw=True)
-        NotificationsService.create(user,
-                                    "success",
-                                    "Completed potree converter (for point cloud {}).".format(pointCloudId))
+        NotificationsService.create_with_rollback(user,
+                                                  "success",
+                                                  "Completed potree converter (for point cloud {}).".format(
+                                                      pointCloudId))
     except:
         logger.exception("point cloud:{} conversion failed for user:{}".format(pointCloudId, user.username))
-        task.status = "FAILED"
-        task.description = ""
-        db_session.add(task)
-        db_session.commit()
-        NotificationsService.create(user, "error", "Processing failed for point cloud ({})!".format(pointCloudId))
+        _update_point_cloud_task(pointCloudId, description="", status="FAILED")
+        NotificationsService.create_with_rollback(user,
+                                                  "error",
+                                                  "Processing failed for point cloud ({})!".format(pointCloudId))
+        return
 
 
 #TODO: Add users to project based on the agave users on the system.
@@ -195,7 +211,8 @@ def import_from_agave(userId: int, systemId: str, path: str, projectId: int):
                 db_session.commit()
 
             except Exception as e:
-                NotificationsService.create(user, "error", "Error importing {f}".format(f=item_system_path))
+                db_session.rollback()
+                NotificationsService.create_with_rollback(user, "error", "Error importing {f}".format(f=item_system_path))
                 logger.exception(e)
                 continue
 

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -109,7 +109,7 @@ def import_point_clouds_from_agave(userId: int, files, pointCloudId: int):
                 logger.error("removing {}!!!!!!!".format(file_path))
                 os.remove(file_path)
             _update_point_cloud_task(pointCloudId, description=failed_message, status="FAILED")
-            NotificationsService.create_with_rollback(user, "error", failed_message)
+            NotificationsService.create(user, "error", failed_message)
             return
 
     _update_point_cloud_task(pointCloudId, description="Running potree converter", status="RUNNING")

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -219,9 +219,13 @@ def import_from_agave(userId: int, systemId: str, path: str, projectId: int):
 
 @app.task()
 def refresh_observable_projects():
-    obs = db_session.query(ObservableDataProject).all()
-    for o in obs:
-        import_from_agave(o.project.users[0].id, o.system_id, o.path, o.project.id)
+    try:
+        obs = db_session.query(ObservableDataProject).all()
+        for o in obs:
+            import_from_agave(o.project.users[0].id, o.system_id, o.path, o.project.id)
+    except Exception:
+        logger.exception("Unhandled exception when importing observable project")
+        db_session.rollback()
 
 
 if __name__ == "__main__":

--- a/geoapi/tasks/lidar.py
+++ b/geoapi/tasks/lidar.py
@@ -128,9 +128,7 @@ def convert_to_potree(self, pointCloudId: int) -> None:
             feature=feature
         )
         feature.assets.append(fa)
-
         point_cloud.feature = feature
-        db_session.add(point_cloud)
 
     feature.the_geom = from_shape(geometries.convert_3D_2D(outline), srid=4326)
     point_cloud.task.status = "FINISHED"
@@ -140,6 +138,10 @@ def convert_to_potree(self, pointCloudId: int) -> None:
     shutil.rmtree(point_cloud_asset_path, ignore_errors=True)
     shutil.move(path_temp_processed_point_cloud_path, point_cloud_asset_path)
 
-    db_session.add(point_cloud)
-    db_session.add(feature)
-    db_session.commit()
+    try:
+        db_session.add(point_cloud)
+        db_session.add(feature)
+        db_session.commit()
+    except:
+        db_session.rollback()
+        raise

--- a/geoapi/tests/conftest.py
+++ b/geoapi/tests/conftest.py
@@ -45,6 +45,7 @@ def userdata(test_client):
     u2 = User(username="test2", jwt=user2JWT, tenant_id="test")
     db_session.add_all([u1, u2])
     db_session.commit()
+    yield u1
 
 
 @pytest.fixture(scope="function")

--- a/geoapi/tests/external_data_tests/test_external_data.py
+++ b/geoapi/tests/external_data_tests/test_external_data.py
@@ -11,39 +11,55 @@ from geoapi.exceptions import InvalidCoordinateReferenceSystem
 from geoapi.services.point_cloud import PointCloudService
 
 
-@patch("geoapi.tasks.external_data.AgaveUtils")
-def test_external_data_good_files(MockAgaveUtils, userdata, projects_fixture, geojson_file_fixture):
-    filesListing = [
-        AgaveFileListing({
-            "system": "testSystem",
-            "path": "/testPath",
-            "type": "dir",
-            "length": 4,
-            "_links": "links",
-            "mimeType": "folder",
-            "lastModified": "2020-08-31T12:00:00Z"
-        }),
-        AgaveFileListing({
-            "system": "testSystem",
-            "type": "file",
-            "length": 4096,
-            "path": "/testPath/file.json",
-            "_links": "links",
-            "mimeType": "application/json",
-            "lastModified": "2020-08-31T12:00:00Z"
-        })
-    ]
+@pytest.fixture(scope="function")
+def rollback_side_effect():
+    with patch('geoapi.db.db_session.rollback', side_effect=db_session.rollback) as rollback:
+        yield rollback
+
+
+@pytest.fixture(scope="function")
+def db_session_commit_throws_exception():
+    with patch('geoapi.db.db_session.commit', side_effect=Exception) as commit:
+        yield commit
+
+@pytest.fixture(scope="function")
+def agave_utils_with_geojson_file(geojson_file_fixture):
+    with patch('geoapi.tasks.external_data.AgaveUtils') as MockAgaveUtils:
+        filesListing = [
+            AgaveFileListing({
+                "system": "testSystem",
+                "path": "/testPath",
+                "type": "dir",
+                "length": 4,
+                "_links": "links",
+                "mimeType": "folder",
+                "lastModified": "2020-08-31T12:00:00Z"
+            }),
+            AgaveFileListing({
+                "system": "testSystem",
+                "type": "file",
+                "length": 4096,
+                "path": "/testPath/file.json",
+                "_links": "links",
+                "mimeType": "application/json",
+                "lastModified": "2020-08-31T12:00:00Z"
+            })
+        ]
+        MockAgaveUtils().listing.return_value = filesListing
+        MockAgaveUtils().getFile.return_value = geojson_file_fixture
+        yield MockAgaveUtils()
+
+
+def test_external_data_good_files(userdata, projects_fixture, agave_utils_with_geojson_file):
     u1 = db_session.query(User).filter(User.username == "test1").first()
-    proj = db_session.query(Project).get(1)
-    MockAgaveUtils().listing.return_value = filesListing
-    MockAgaveUtils().getFile.return_value = geojson_file_fixture
-    import_from_agave(u1.id, "testSystem", "/testPath", proj.id)
+
+    import_from_agave(u1.id, "testSystem", "/testPath", projects_fixture.id)
     features = db_session.query(Feature).all()
     # the test geojson has 3 features in it
     assert len(features) == 3
     # This should only have been called once, since there is only
     # one FILE in the listing
-    assert MockAgaveUtils().getFile.called_once()
+    agave_utils_with_geojson_file.getFile.assert_called_once()
 
 
 @pytest.mark.worker
@@ -71,10 +87,10 @@ def test_import_point_clouds_from_agave(MockAgaveUtils,
 @patch("geoapi.tasks.external_data.check_point_cloud")
 @patch("geoapi.tasks.external_data.AgaveUtils")
 def test_import_point_clouds_from_agave_check_point_cloud_missing_crs(MockAgaveUtils,
-                                        check_mock,
-                                        projects_fixture,
-                                        point_cloud_fixture,
-                                        lidar_las1pt2_file_fixture):
+                                                                      check_mock,
+                                                                      projects_fixture,
+                                                                      point_cloud_fixture,
+                                                                      lidar_las1pt2_file_fixture):
     MockAgaveUtils().getFile.return_value = lidar_las1pt2_file_fixture
     check_mock.apply.side_effect = InvalidCoordinateReferenceSystem()
 
@@ -92,10 +108,10 @@ def test_import_point_clouds_from_agave_check_point_cloud_missing_crs(MockAgaveU
 @patch("geoapi.tasks.external_data.check_point_cloud")
 @patch("geoapi.tasks.external_data.AgaveUtils")
 def test_import_point_clouds_from_agave_check_point_cloud_unknown(MockAgaveUtils,
-                                        check_mock,
-                                        projects_fixture,
-                                        point_cloud_fixture,
-                                        lidar_las1pt2_file_fixture):
+                                                                  check_mock,
+                                                                  projects_fixture,
+                                                                  point_cloud_fixture,
+                                                                  lidar_las1pt2_file_fixture):
     MockAgaveUtils().getFile.return_value = lidar_las1pt2_file_fixture
     check_mock.apply.side_effect = Exception("dummy")
 
@@ -113,10 +129,10 @@ def test_import_point_clouds_from_agave_check_point_cloud_unknown(MockAgaveUtils
 @patch("geoapi.tasks.external_data.convert_to_potree")
 @patch("geoapi.tasks.external_data.AgaveUtils")
 def test_import_point_clouds_from_agave_conversion_error(MockAgaveUtils,
-                                        convert_mock,
-                                        projects_fixture,
-                                        point_cloud_fixture,
-                                        lidar_las1pt2_file_fixture):
+                                                         convert_mock,
+                                                         projects_fixture,
+                                                         point_cloud_fixture,
+                                                         lidar_las1pt2_file_fixture):
     MockAgaveUtils().getFile.return_value = lidar_las1pt2_file_fixture
     convert_mock.apply.side_effect = Exception("dummy")
 
@@ -128,3 +144,33 @@ def test_import_point_clouds_from_agave_conversion_error(MockAgaveUtils,
     assert point_cloud.task.status == "FAILED"
     assert point_cloud.task.description == ""
     assert len(os.listdir(get_asset_path(point_cloud_fixture.path, PointCloudService.ORIGINAL_FILES_DIR))) == 1
+
+
+@pytest.mark.worker
+@patch("geoapi.tasks.external_data.AgaveUtils")
+def test_import_point_clouds_failed_dbsession_rollback(MockAgaveUtils,
+                                                       projects_fixture,
+                                                       point_cloud_fixture,
+                                                       lidar_las1pt2_file_fixture,
+                                                       db_session_commit_throws_exception,
+                                                       rollback_side_effect):
+    MockAgaveUtils().getFile.return_value = lidar_las1pt2_file_fixture
+
+    u1 = db_session.query(User).get(1)
+    files = [{"system": "designsafe.storage.default", "path": "file1.las"}]
+
+    with pytest.raises(Exception):
+        import_point_clouds_from_agave(u1.id, files, point_cloud_fixture.id)
+
+    rollback_side_effect.assert_called_once()
+
+
+def test_import_from_agave_failed_dbsession_rollback(agave_utils_with_geojson_file,
+                                                     userdata,
+                                                     projects_fixture,
+                                                     db_session_commit_throws_exception,
+                                                     rollback_side_effect):
+    with pytest.raises(Exception):
+        import_from_agave(userdata.id, "testSystem", "/testPath", projects_fixture.id)
+
+    rollback_side_effect.assert_called()

--- a/geoapi/utils/decorators.py
+++ b/geoapi/utils/decorators.py
@@ -104,6 +104,8 @@ def project_point_cloud_not_processing(fn):
         point_cloud = PointCloudService.get(point_cloud_id)
         if point_cloud.task \
                 and point_cloud.task.status not in ["FINISHED", "FAILED"]:
+            logger.info("point cloud:{} is not in terminal state".format(
+                point_cloud_id))
             abort(404, "Point cloud is currently being updated")
         return fn(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
## Overview: ##

Add rollback to worker tasks

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-9999](https://jira.tacc.utexas.edu/browse/DES-9999)

## Summary of Changes: ##
* Add rollback to worker tasks
* Rollback on any unhandled exceptions in observable projects
* Add related unit tests to check for rollback

## Notes: ##
 Completed since last time we discussed this
- [x] add tests to ensure 
- [x] confirm rollback and alternatives
- [x] look for possible 3d not being squashed which caused one problem we saw  in production:  _could possibly be this: [DES-1730](https://jira.tacc.utexas.edu/browse/DES-1730) but most likely connection error (see logs)[DES-1730](https://jira.tacc.utexas.edu/browse/DES-1730)_
- [x] check logging statements to make sure we our printing paths to problem files: _handling in a different task/PR: [DES-1728](https://jira.tacc.utexas.edu/browse/DES-1728)_