### PR TITLE
DES-1676 - Add update functionality to individual projects.

### DIFF
--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -186,9 +186,14 @@ class ProjectResource(Resource):
 
     @api.doc(id="updateProject",
              description="Update metadata about a project")
+    @api.marshal_with(project)
     @project_permissions
     def put(self, projectId: int):
-        return True
+        u = request.current_user
+        logger.info("Update project:{} for user".format(projectId,
+                                                        u.username))
+        return ProjectsService.update(projectId=projectId,
+                                      data=api.payload)
 
 
 @api.route('/<int:projectId>/users/')

--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -190,8 +190,8 @@ class ProjectResource(Resource):
     @project_permissions
     def put(self, projectId: int):
         u = request.current_user
-        logger.info("Update project:{} for user".format(projectId,
-                                                        u.username))
+        logger.info("Update project:{} for user:{}".format(projectId,
+                                                           u.username))
         return ProjectsService.update(projectId=projectId,
                                       data=api.payload)
 

--- a/geoapi/services/projects.py
+++ b/geoapi/services/projects.py
@@ -182,7 +182,7 @@ class ProjectsService:
 
         # The sub select that filters only on this projects ID, filters applied below
         sub_select = select([
-            text("""feat.*,  array_remove(array_agg(fa), null) as assets 
+            text("""feat.*,  array_remove(array_agg(fa), null) as assets
               from features as feat
               LEFT JOIN feature_assets fa on feat.id = fa.feature_id
              """)
@@ -211,8 +211,20 @@ class ProjectsService:
         return out.geojson
 
     @staticmethod
-    def update(projectId: int, data) -> Project:
-        pass
+    def update(projectId: int, data: dict) -> Project:
+        """
+        Update the metadata associated with a project
+        :param projectId: int
+        :param data: dict
+        :return: Project
+        """
+        current_project = ProjectsService.get(projectId)
+
+        current_project.name = data['name']
+        current_project.description = data['description']
+        db_session.commit()
+
+        return current_project
 
     @staticmethod
     def delete(projectId: int) -> dict:

--- a/geoapi/tests/api_tests/test_projects_routes.py
+++ b/geoapi/tests/api_tests/test_projects_routes.py
@@ -231,7 +231,7 @@ def test_observable_project_already_exists(test_client,
     assert resp.status_code == 409
     assert "Conflict, a project for this storage system/path already exists" in resp.json['message']
 
-def test_update_project(test_client, projects_fixture, point_cloud_fixture):
+def test_update_project(test_client, projects_fixture):
     u1 = db_session.query(User).get(1)
     data = {'name': "Renamed Project", 'description': "New Description"}
     resp = test_client.put(
@@ -243,7 +243,4 @@ def test_update_project(test_client, projects_fixture, point_cloud_fixture):
     proj = db_session.query(Project).get(1)
     assert proj.name == "Renamed Project"
     assert proj.description == "New Description"
-    # Reset data
-    proj.name == "test"
-    proj.description == "description"
     db_session.commit()

--- a/geoapi/tests/api_tests/test_projects_routes.py
+++ b/geoapi/tests/api_tests/test_projects_routes.py
@@ -231,3 +231,19 @@ def test_observable_project_already_exists(test_client,
     assert resp.status_code == 409
     assert "Conflict, a project for this storage system/path already exists" in resp.json['message']
 
+def test_update_project(test_client, projects_fixture, point_cloud_fixture):
+    u1 = db_session.query(User).get(1)
+    data = {'name': "Renamed Project", 'description': "New Description"}
+    resp = test_client.put(
+        '/projects/1/',
+        json=data,
+        headers={'x-jwt-assertion-test': u1.jwt}
+    )
+    assert resp.status_code == 200
+    proj = db_session.query(Project).get(1)
+    assert proj.name == "Renamed Project"
+    assert proj.description == "New Description"
+    # Reset data
+    proj.name == "test"
+    proj.description == "description"
+    db_session.commit()

--- a/geoapi/tests/api_tests/test_projects_service.py
+++ b/geoapi/tests/api_tests/test_projects_service.py
@@ -63,3 +63,12 @@ def test_get_features_filter_type(projects_fixture,
     query = {'assetType': 'video'}
     project_features = ProjectsService.getFeatures(projects_fixture.id, query)
     assert len(project_features['features']) == 0
+
+def test_update_project(projects_fixture):
+    data = {
+        "name": "new name",
+        "description": "new description"
+    }
+    proj = ProjectsService.update(projects_fixture.id, data)
+    assert proj.name == "new name"
+    assert proj.description == "new description"


### PR DESCRIPTION
## Overview: ##
This adds a handle to PUT requests to enable update functionality for projects in the backend.
This was mainly needed to implement updating for a project's name and description from the user panel. 

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1676](https://jira.tacc.utexas.edu/browse/DES-1676)

## Summary of Changes: ##
I've created new update methods for the project service and route. 
Furthermore, I've tried to implement test for the corresponding methods.

## Testing Steps: ##
1. Run tests.

## Notes: ##