### PR TITLE
Task/DES-1899 support querying projects by UUID

### DIFF
--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -1,4 +1,4 @@
-from flask import request, abort
+from flask import request
 from flask_restplus import Resource, Namespace, fields, inputs
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
@@ -140,6 +140,7 @@ overlay_parser_tapis = overlay_parser.copy()
 overlay_parser_tapis.remove_argument('file')
 overlay_parser_tapis.add_argument('system_id', location='json', type=str, required=True)
 overlay_parser_tapis.add_argument('path', location='json', type=str, required=True)
+
 
 @api.route('/')
 class ProjectsListing(Resource):
@@ -597,6 +598,7 @@ class ProjectTasksResource(Resource):
         from geoapi.db import db_session
         return db_session.query(Task).all()
 
+
 @api.route('/<int:projectId>/tile-servers/')
 class ProjectTileServersResource(Resource):
     @api.doc(id="addTileServer",
@@ -611,7 +613,6 @@ class ProjectTileServersResource(Resource):
         ts = FeaturesService.addTileServer(projectId, api.payload)
         return ts
 
-
     @api.doc(id="getTileServers",
              description='Get a list of all the tile servers associated with the current map project.')
     @api.marshal_with(tile_server, as_list=True)
@@ -619,7 +620,6 @@ class ProjectTileServersResource(Resource):
     def get(self, projectId: int):
         tsv = FeaturesService.getTileServers(projectId)
         return tsv
-
 
     @api.doc(id="updateTileServers",
              description="Update metadata about a tile servers")
@@ -631,7 +631,7 @@ class ProjectTileServersResource(Resource):
                                                            u.username))
 
         ts = FeaturesService.updateTileServers(projectId=projectId,
-                                                 dataList=api.payload)
+                                               dataList=api.payload)
         return ts
 
 
@@ -647,7 +647,6 @@ class ProjectTileServerResource(Resource):
         FeaturesService.deleteTileServer(projectId, tileServerId)
         return "Tile Server {id} deleted".format(id=tileServerId)
 
-
     @api.doc(id="updateTileServer",
              description="Update metadata about a tile server")
     @api.marshal_with(tile_server)
@@ -656,7 +655,6 @@ class ProjectTileServerResource(Resource):
         u = request.current_user
         logger.info("Update project:{} for user:{}".format(projectId,
                                                            u.username))
-
 
         return FeaturesService.updateTileServer(projectId=projectId,
                                                 tileServerId=tileServerId,

--- a/geoapi/services/projects.py
+++ b/geoapi/services/projects.py
@@ -1,6 +1,6 @@
 import shutil
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from sqlalchemy import desc
 from geoapi.models import Project, User, ObservableDataProject
@@ -99,13 +99,19 @@ class ProjectsService:
         return projects
 
     @staticmethod
-    def get(projectId: int) -> Project:
+    def get(project_id: Optional[int] = None, uuid: Optional[str] = None) -> Project:
         """
         Get the metadata associated with a project
-        :param projectId: int
+        :param project_id: int
+        :param uid: str
         :return: Project
         """
-        return db_session.query(Project).get(projectId)
+        if project_id is not None:
+            return db_session.query(Project).get(project_id)
+        elif uuid is not None:
+            return db_session.query(Project).filter(Project.uuid == uuid).first()
+        raise ValueError("project_id or uid is required")
+
 
     @staticmethod
     def getFeatures(projectId: int, query: dict = None) -> object:
@@ -218,7 +224,7 @@ class ProjectsService:
         :param data: dict
         :return: Project
         """
-        current_project = ProjectsService.get(projectId)
+        current_project = ProjectsService.get(project_id=projectId)
 
         current_project.name = data['name']
         if 'description' in data:

--- a/geoapi/tests/api_tests/test_projects_routes.py
+++ b/geoapi/tests/api_tests/test_projects_routes.py
@@ -13,6 +13,30 @@ def test_get_projects(test_client, projects_fixture):
     assert len(data) == 1
 
 
+def test_get_projects_using_uuids(test_client, projects_fixture, projects_fixture2):
+    requested_uuids = [str(projects_fixture2.uuid), str(projects_fixture.uuid)]
+    u1 = db_session.query(User).get(1)
+    resp = test_client.get('/projects/',
+                           query_string='uuid={}'.format(','.join(requested_uuids)),
+                           headers={'x-jwt-assertion-test': u1.jwt})
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert len(data) == 2
+    assert data[0]["uuid"] == requested_uuids[0]
+    assert data[1]["uuid"] == requested_uuids[1]
+
+
+def test_get_projects_using_single_uuid(test_client, projects_fixture, projects_fixture2):
+    u1 = db_session.query(User).get(1)
+    resp = test_client.get('/projects/',
+                           query_string='uuid={}'.format(projects_fixture2.uuid),
+                           headers={'x-jwt-assertion-test': u1.jwt})
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert len(data) == 1
+    assert data[0]["uuid"] == str(projects_fixture2.uuid)
+
+
 def test_project_permissions(test_client, projects_fixture):
     u2 = db_session.query(User).get(2)
     resp = test_client.get('/projects/', headers={'x-jwt-assertion-test': u2.jwt})

--- a/geoapi/tests/api_tests/test_projects_routes.py
+++ b/geoapi/tests/api_tests/test_projects_routes.py
@@ -316,7 +316,7 @@ def test_update_project(test_client, projects_fixture):
     proj = db_session.query(Project).get(1)
     assert proj.name == "Renamed Project"
     assert proj.description == "New Description"
-    assert proj.public == True
+    assert proj.public
 
 
 def test_update_project_unauthorized_guest(test_client, public_projects_fixture):

--- a/geoapi/tests/api_tests/test_projects_service.py
+++ b/geoapi/tests/api_tests/test_projects_service.py
@@ -45,6 +45,21 @@ def test_create_observable_project_already_exists(observable_projects_fixture,
         ProjectsService.createRapidProject(data, user)
 
 
+def test_get_with_project_id(projects_fixture):
+    project = ProjectsService.get(project_id=projects_fixture.id)
+    assert project.id == projects_fixture.id
+
+
+def test_get_with_uid(projects_fixture):
+    project = ProjectsService.get(uuid=projects_fixture.uuid)
+    assert project.uuid == projects_fixture.uuid
+
+
+def test_get_missing_argument(projects_fixture):
+    with pytest.raises(ValueError):
+        ProjectsService.get()
+
+
 def test_get_features(projects_fixture, feature_fixture):
     project_features = ProjectsService.getFeatures(projects_fixture.id)
     assert len(project_features['features']) == 1

--- a/geoapi/tests/api_tests/test_users_service.py
+++ b/geoapi/tests/api_tests/test_users_service.py
@@ -38,7 +38,7 @@ def test_add_new_user_to_project(userdata):
     }
     proj = ProjectsService.create(data, user)
     ProjectsService.addUserToProject(proj.id, "newUser")
-    proj = ProjectsService.get(proj.id)
+    proj = ProjectsService.get(project_id=proj.id)
     assert len(proj.users) == 2
 
 

--- a/geoapi/tests/conftest.py
+++ b/geoapi/tests/conftest.py
@@ -63,6 +63,19 @@ def projects_fixture():
 
 
 @pytest.fixture(scope="function")
+def projects_fixture2():
+    proj = Project(name="test2", description="description2")
+    u1 = db_session.query(User).filter(User.username == "test1").first()
+    proj.users.append(u1)
+    proj.tenant_id = u1.tenant_id
+    db_session.add(proj)
+    db_session.commit()
+    yield proj
+
+    shutil.rmtree(get_project_asset_dir(proj.id), ignore_errors=True)
+
+
+@pytest.fixture(scope="function")
 def public_projects_fixture(projects_fixture):
     projects_fixture.public = True
     db_session.add(projects_fixture)


### PR DESCRIPTION
## Overview: ##

Support querying of projects by UUID

## Related Jira tickets: ##

* [DES-1899](https://jira.tacc.utexas.edu/browse/DES-1899)

## Summary of Changes: ##

The `GET` for `/projects` now supports a query parameter `uuid`.  So you can request a list of uuids instead of getting all the projects (e.g. `/projects/?uuid=12345567777` to get one project  or `/projects/?uuid=12345567777,ABCDEFGHIG` to get multiple)

## Testing Steps: ##
1. Run unit tests
2. (optional) make queries to local server

