### PR TITLE
hotfix:  travis's CI deploy/script has to be a one line command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,7 @@ jobs:
          - docker tag taccaci/geoapi:latest taccaci/geoapi:${GIT_HASH}
       deploy:
         provider: script
-        script:
-          - docker push taccaci/geoapi:latest
-          - docker push taccaci/geoapi:${GIT_HASH}
+        script: docker push taccaci/geoapi:latest && docker push taccaci/geoapi:${GIT_HASH}
         on:
           branch: master
     - name: "geoapi-workers: unit tests / container"
@@ -47,8 +45,6 @@ jobs:
          - docker tag taccaci/geoapi-workers:latest taccaci/geoapi-workers:${GIT_HASH}
       deploy:
         provider: script
-        script:
-          - docker push taccaci/geoapi-workers:latest
-          - docker push taccaci/geoapi-workers:${GIT_HASH}
+        script: docker push taccaci/geoapi-workers:latest && docker push taccaci/geoapi-workers:${GIT_HASH}
         on:
           branch: master


### PR DESCRIPTION
## Overview: ##

Travis's CI deploy/script has to be a one line command. See travis-ci/dpl#673

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

_None_

