### PR TITLE
Task/des 1788 support public maps for new and missing routes

### DIFF
--- a/geoapi/routes/notifications.py
+++ b/geoapi/routes/notifications.py
@@ -2,7 +2,7 @@ from flask import request, abort
 from flask_restplus import Resource, Namespace, fields, inputs
 
 from geoapi.log import logging
-from geoapi.utils.decorators import jwt_decoder
+from geoapi.utils.decorators import jwt_decoder, not_anonymous
 from geoapi.services.notifications import NotificationsService
 from dateutil import parser, tz
 
@@ -32,6 +32,7 @@ class Notifcations(Resource):
     @api.doc(id="get",
              description='Get a list of notifications')
     @api.marshal_with(notification_response, as_list=True)
+    @not_anonymous
     def get(self):
         query = self.parser.parse_args()
         u = request.current_user

--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -9,7 +9,7 @@ from geoapi.services.features import FeaturesService
 from geoapi.services.projects import ProjectsService
 from geoapi.services.point_cloud import PointCloudService
 from geoapi.utils.decorators import jwt_decoder, project_permissions_allow_public, project_permissions, project_feature_exists, \
-    project_point_cloud_exists, project_point_cloud_not_processing
+    project_point_cloud_exists, project_point_cloud_not_processing, check_access_and_get_project
 from geoapi.tasks import external_data
 
 logger = logging.getLogger(__name__)
@@ -159,7 +159,9 @@ class ProjectsListing(Resource):
         uuid_subset = query.get("uuid")
 
         if uuid_subset:
-            subset = [ProjectsService.get(uuid=uuid) for uuid in uuid_subset]
+            logger.info("Get a subset of projects for user:{} projects:{}".format(u.username, uuid_subset))
+            # Check each project and abort if user (authenticated or anonymous) can't access the project
+            subset = [check_access_and_get_project(request.current_user, uuid=uuid, allow_public_use=True) for uuid in uuid_subset]
             return subset
         else:
             logger.info("Get all projects for user:{}".format(u.username))

--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -491,7 +491,7 @@ class ProjectPointCloudsResource(Resource):
     @api.doc(id="getAllPointClouds",
              description="Get a listing of all the points clouds of a project")
     @api.marshal_with(point_cloud, as_list=True)
-    @project_permissions
+    @project_permissions_allow_public
     def get(self, projectId: int):
         return PointCloudService.list(projectId)
 
@@ -616,7 +616,7 @@ class ProjectTileServersResource(Resource):
     @api.doc(id="getTileServers",
              description='Get a list of all the tile servers associated with the current map project.')
     @api.marshal_with(tile_server, as_list=True)
-    @project_permissions
+    @project_permissions_allow_public
     def get(self, projectId: int):
         tsv = FeaturesService.getTileServers(projectId)
         return tsv

--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -514,7 +514,7 @@ class ProjectPointCloudResource(Resource):
     @api.doc(id="getPointCloud",
              description="Get point cloud of a project")
     @api.marshal_with(point_cloud)
-    @project_permissions
+    @project_permissions_allow_public
     def get(self, projectId: int, pointCloudId: int):
         return PointCloudService.get(pointCloudId)
 

--- a/geoapi/services/features.py
+++ b/geoapi/services/features.py
@@ -57,12 +57,10 @@ class FeaturesService:
     )
 
     ALLOWED_GEOSPATIAL_EXTENSIONS = IMAGE_FILE_EXTENSIONS + GPX_FILE_EXTENSIONS + GEOJSON_FILE_EXTENSIONS + \
-                                    SHAPEFILE_FILE_EXTENSIONS
+        SHAPEFILE_FILE_EXTENSIONS
 
-    ALLOWED_EXTENSIONS = IMAGE_FILE_EXTENSIONS + VIDEO_FILE_EXTENSIONS \
-                         + AUDIO_FILE_EXTENSIONS + GPX_FILE_EXTENSIONS \
-                         + GEOJSON_FILE_EXTENSIONS + SHAPEFILE_FILE_EXTENSIONS \
-                         + INI_FILE_EXTENSIONS
+    ALLOWED_EXTENSIONS = IMAGE_FILE_EXTENSIONS + VIDEO_FILE_EXTENSIONS + AUDIO_FILE_EXTENSIONS + GPX_FILE_EXTENSIONS + \
+        GEOJSON_FILE_EXTENSIONS + SHAPEFILE_FILE_EXTENSIONS + INI_FILE_EXTENSIONS
 
     @staticmethod
     def get(featureId: int) -> Feature:
@@ -359,7 +357,6 @@ class FeaturesService:
         db_session.commit()
         return feat
 
-
     @staticmethod
     def createFeatureAssetFromTapis(user: User, projectId: int, featureId: int, systemId: str, path: str) -> Feature:
         """
@@ -407,7 +404,7 @@ class FeaturesService:
         return fa
 
     @staticmethod
-    def createVideoFeatureAsset(projectId: int, fileObj: IO, original_path:str =None) -> FeatureAsset:
+    def createVideoFeatureAsset(projectId: int, fileObj: IO, original_path: str =None) -> FeatureAsset:
         """
 
         :param projectId:
@@ -501,7 +498,6 @@ class FeaturesService:
         db_session.commit()
         return ov
 
-
     @staticmethod
     def addOverlayFromTapis(user: User, project_id: int, system_id: str,
                             path: str, bounds: List[float], label: str) -> Overlay:
@@ -509,7 +505,6 @@ class FeaturesService:
         file_obj = client.getFile(system_id, path)
         ov = FeaturesService.addOverlay(project_id, file_obj, bounds, label)
         return ov
-
 
     @staticmethod
     def getOverlays(projectId: int) -> List[Overlay]:
@@ -522,7 +517,6 @@ class FeaturesService:
         delete_assets(projectId=projectId, uuid=ov.uuid)
         db_session.delete(ov)
         db_session.commit()
-
 
     @staticmethod
     def addTileServer(projectId: int, data: Dict):

--- a/geoapi/tests/api_tests/test_notifications_routes.py
+++ b/geoapi/tests/api_tests/test_notifications_routes.py
@@ -1,5 +1,5 @@
 import pytest
-from geoapi.models import User, Notification
+from geoapi.models import User
 from geoapi.db import db_session
 from geoapi.services.notifications import NotificationsService
 
@@ -7,7 +7,6 @@ from geoapi.services.notifications import NotificationsService
 @pytest.fixture
 def notifications(userdata):
     u1 = db_session.query(User).filter(User.username == "test1").first()
-    u2 = db_session.query(User).filter(User.username == "test2").first()
     NotificationsService.create(u1, "error", "test error")
     NotificationsService.create(u1, "success", "test success")
 
@@ -16,25 +15,27 @@ def test_get_notifications(test_client, notifications):
     u1 = db_session.query(User).get(1)
 
     resp = test_client.get('/notifications/',
-                            headers={'x-jwt-assertion-test': u1.jwt})
+                           headers={'x-jwt-assertion-test': u1.jwt})
     data = resp.get_json()
     assert resp.status_code == 200
     assert len(data) == 2
+
 
 def test_filter_notifications(test_client, notifications):
     u1 = db_session.query(User).get(1)
 
     resp = test_client.get('/notifications/?startDate=2222-1-1T12:00:00+00:00',
-                            headers={'x-jwt-assertion-test': u1.jwt})
+                           headers={'x-jwt-assertion-test': u1.jwt})
     data = resp.get_json()
     assert resp.status_code == 200
     assert len(data) == 0
+
 
 def test_filter_notifications_positive(test_client, notifications):
     u1 = db_session.query(User).get(1)
 
     resp = test_client.get('/notifications/?startDate=1900-1-1T12:00:00+00:00',
-                            headers={'x-jwt-assertion-test': u1.jwt})
+                           headers={'x-jwt-assertion-test': u1.jwt})
     data = resp.get_json()
     assert resp.status_code == 200
     assert len(data) == 2

--- a/geoapi/tests/api_tests/test_notifications_routes.py
+++ b/geoapi/tests/api_tests/test_notifications_routes.py
@@ -11,6 +11,11 @@ def notifications(userdata):
     NotificationsService.create(u1, "success", "test success")
 
 
+def test_get_notifications_unauthorized_guest(test_client, projects_fixture):
+    resp = test_client.get('/notifications/')
+    assert resp.status_code == 403
+
+
 def test_get_notifications(test_client, notifications):
     u1 = db_session.query(User).get(1)
 

--- a/geoapi/tests/api_tests/test_point_cloud_routes.py
+++ b/geoapi/tests/api_tests/test_point_cloud_routes.py
@@ -17,8 +17,8 @@ def test_get_point_cloud(test_client, projects_fixture, point_cloud_fixture):
     assert resp.status_code == 200
 
 
-def test_get_point_cloud_public_access(test_client, projects_fixture, point_cloud_fixture):
-    resp = test_client.get('/projects/1/point-cloud/1/', headers={'x-jwt-assertion-test': u1.jwt})
+def test_get_point_cloud_public_access(test_client, public_projects_fixture, point_cloud_fixture):
+    resp = test_client.get('/projects/1/point-cloud/1/')
     assert resp.status_code == 200
 
 

--- a/geoapi/tests/api_tests/test_point_cloud_routes.py
+++ b/geoapi/tests/api_tests/test_point_cloud_routes.py
@@ -17,6 +17,11 @@ def test_get_point_cloud(test_client, projects_fixture, point_cloud_fixture):
     assert resp.status_code == 200
 
 
+def test_get_point_cloud_public_access(test_client, projects_fixture, point_cloud_fixture):
+    resp = test_client.get('/projects/1/point-cloud/1/', headers={'x-jwt-assertion-test': u1.jwt})
+    assert resp.status_code == 200
+
+
 def test_create_point_cloud(test_client, projects_fixture):
     u1 = db_session.query(User).get(1)
     data = {'description': "new description", 'conversion_parameters': "--scale 5.0"}

--- a/geoapi/utils/decorators.py
+++ b/geoapi/utils/decorators.py
@@ -138,3 +138,12 @@ def project_point_cloud_not_processing(fn):
             abort(404, "Point cloud is currently being updated")
         return fn(*args, **kwargs)
     return wrapper
+
+
+def not_anonymous(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        if is_anonymous(request.current_user):
+            abort(403, "Access denied")
+        return fn(*args, **kwargs)
+    return wrapper


### PR DESCRIPTION
## Overview: ##

Add additional support for public maps (follow on to PR #40 )

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-1788](https://jira.tacc.utexas.edu/browse/DES-1788 )

## Summary of Changes: ##
- Add decorator to allow some routes to be used by the public (was missing tile server, point cloud)
- Add not_anonymous decorator to be used on notifications get
- Fix some pep8 things
- Lock down getting the metadata for projects
