### PR TITLE
Des 1946 provide public routes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+TAG := $(shell git log --format=%h -1)
+GEOAPI_IMAGE=taccaci/geoapi
+GEOAPI_WORKERS=taccaci/geoapi-workers
+
+.PHONY: geoapi
+geoapi:
+	docker build -t $(GEOAPI_IMAGE):$(TAG) .
+
+.PHONY: workers
+workers:
+	docker build -t $(GEOAPI_WORKERS):$(TAG) -f Dockerfile.potree .
+
+.PHONY: deploy-geoapi
+deploy-geoapi:
+	docker push $(GEOAPI_IMAGE):$(TAG)
+
+.PHONY: deploy-workers
+deploy-workers:
+	docker push $(GEOAPI_WORKERS):$(TAG)

--- a/geoapi/routes/__init__.py
+++ b/geoapi/routes/__init__.py
@@ -1,6 +1,7 @@
 from flask_restplus import Api
 from .projects import api as projects
-from .notifications import api  as notifications
+from .public_projects import api as public_projects
+from .notifications import api as notifications
 api = Api(
     title='GeoAPI',
     version='0.1',
@@ -21,5 +22,6 @@ api = Api(
 )
 
 api.add_namespace(projects)
+api.add_namespace(public_projects)
 api.add_namespace(notifications)
 

--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -1,4 +1,4 @@
-from flask import request
+from flask import request, abort
 from flask_restplus import Resource, Namespace, fields, inputs
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
@@ -9,7 +9,7 @@ from geoapi.services.features import FeaturesService
 from geoapi.services.projects import ProjectsService
 from geoapi.services.point_cloud import PointCloudService
 from geoapi.utils.decorators import jwt_decoder, project_permissions_allow_public, project_permissions, project_feature_exists, \
-    project_point_cloud_exists, project_point_cloud_not_processing, check_access_and_get_project
+    project_point_cloud_exists, project_point_cloud_not_processing, check_access_and_get_project, is_anonymous
 from geoapi.tasks import external_data
 
 logger = logging.getLogger(__name__)
@@ -164,6 +164,8 @@ class ProjectsListing(Resource):
             subset = [check_access_and_get_project(request.current_user, uuid=uuid, allow_public_use=True) for uuid in uuid_subset]
             return subset
         else:
+            if is_anonymous(u):
+                abort(403, "Access denied")
             logger.info("Get all projects for user:{}".format(u.username))
             return ProjectsService.list(u)
 

--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -264,7 +264,6 @@ class ProjectUserResource(Resource):
 
 @api.route('/<int:projectId>/features/')
 class ProjectFeaturesResource(Resource):
-
     parser = api.parser()
     parser.add_argument("assetType", location="args")
     parser.add_argument('bbox',

--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -130,11 +130,11 @@ tapis_files_import = api.model('TapisFileImport', {
 
 overlay_parser = api.parser()
 overlay_parser.add_argument('file', location='files', type=FileStorage, required=True)
-overlay_parser.add_argument('label', location=['form', 'json'], type=str, required=True)
-overlay_parser.add_argument('minLon', location=['form', 'json'], type=float, required=True)
-overlay_parser.add_argument('minLat', location=['form', 'json'], type=float, required=True)
-overlay_parser.add_argument('maxLon', location=['form', 'json'], type=float, required=True)
-overlay_parser.add_argument('maxLat', location=['form', 'json'], type=float, required=True)
+overlay_parser.add_argument('label', location=('form', 'json'), type=str, required=True)
+overlay_parser.add_argument('minLon', location=('form', 'json'), type=float, required=True)
+overlay_parser.add_argument('minLat', location=('form', 'json'), type=float, required=True)
+overlay_parser.add_argument('maxLon', location=('form', 'json'), type=float, required=True)
+overlay_parser.add_argument('maxLat', location=('form', 'json'), type=float, required=True)
 
 overlay_parser_tapis = overlay_parser.copy()
 overlay_parser_tapis.remove_argument('file')

--- a/geoapi/routes/public_projects.py
+++ b/geoapi/routes/public_projects.py
@@ -1,3 +1,11 @@
+"""
+This module provides public-projects route for use by guest users accessing
+public projects.  This duplicates multiple GET routes in projects.py and
+allows us to provide access to guests (via WSO2 configuration for guests:
+`auth-type=None`). See https://jira.tacc.utexas.edu/browse/DES-1946 for
+more details.
+ """
+
 from flask_restplus import Namespace
 from flask.views import MethodView
 from geoapi.utils.decorators import jwt_decoder
@@ -11,6 +19,7 @@ api = Namespace('public-projects', decorators=[jwt_decoder])
 
 
 class HideNonPublicMeta(type(MethodView)):
+    """ Metaclass to limit the `methods` (defined in MethodViewType) to just GET """
     def __init__(cls, name, bases, d):
         super().__init__(name, bases, d)
         # provide only GET so that our view no longer provides any potentially

--- a/geoapi/routes/public_projects.py
+++ b/geoapi/routes/public_projects.py
@@ -10,8 +10,10 @@ from flask_restplus import Namespace
 from flask.views import MethodView
 from geoapi.utils.decorators import jwt_decoder
 from geoapi.log import logging
-from geoapi.routes.projects import (ProjectsListing, ProjectResource, ProjectFeaturesResource, ProjectFeatureResource,
-                                    ProjectOverlaysResource, ProjectPointCloudResource, ProjectTileServersResource)
+from geoapi.routes.projects import (ProjectsListing, ProjectResource,
+                                    ProjectFeaturesResource, ProjectFeatureResource,
+                                    ProjectOverlaysResource, ProjectPointCloudResource,
+                                    ProjectPointCloudsResource, ProjectTileServersResource)
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +51,11 @@ class PublicProjectFeatureResource(ProjectFeatureResource, metaclass=HideNonPubl
 
 @api.route('/<int:projectId>/overlays/')
 class PublicProjectOverlaysResource(ProjectOverlaysResource, metaclass=HideNonPublicMeta):
+    pass
+
+
+@api.route('/<int:projectId>/point-cloud/')
+class PublicProjectPointCloudsResource(ProjectPointCloudsResource, metaclass=HideNonPublicMeta):
     pass
 
 

--- a/geoapi/routes/public_projects.py
+++ b/geoapi/routes/public_projects.py
@@ -1,0 +1,53 @@
+from flask_restplus import Namespace
+from flask.views import MethodView
+from geoapi.utils.decorators import jwt_decoder
+from geoapi.log import logging
+from geoapi.routes.projects import (ProjectsListing, ProjectResource, ProjectFeaturesResource, ProjectFeatureResource,
+                                    ProjectOverlaysResource, ProjectPointCloudResource, ProjectTileServersResource)
+
+logger = logging.getLogger(__name__)
+
+api = Namespace('public-projects', decorators=[jwt_decoder])
+
+
+class HideNonPublicMeta(type(MethodView)):
+    def __init__(cls, name, bases, d):
+        super().__init__(name, bases, d)
+        # provide only GET so that our view no longer provides any potentially
+        # defined PUT, POST, PATCH, DELETE methods
+        cls.methods = ["GET"]
+
+
+@api.route('/')
+class PublicProjectsListing(ProjectsListing, metaclass=HideNonPublicMeta):
+    pass
+
+
+@api.route('/<int:projectId>/')
+class PublicProjectResource(ProjectResource, metaclass=HideNonPublicMeta):
+    pass
+
+
+@api.route('/<int:projectId>/features/')
+class PublicProjectFeaturesResource(ProjectFeaturesResource, metaclass=HideNonPublicMeta):
+    pass
+
+
+@api.route('/<int:projectId>/features/<int:featureId>/')
+class PublicProjectFeatureResource(ProjectFeatureResource, metaclass=HideNonPublicMeta):
+    pass
+
+
+@api.route('/<int:projectId>/overlays/')
+class PublicProjectOverlaysResource(ProjectOverlaysResource, metaclass=HideNonPublicMeta):
+    pass
+
+
+@api.route('/<int:projectId>/point-cloud/<int:pointCloudId>/')
+class PublicProjectPointCloudResource(ProjectPointCloudResource, metaclass=HideNonPublicMeta):
+    pass
+
+
+@api.route('/<int:projectId>/tile-servers/')
+class PublicProjectTileServersResource(ProjectTileServersResource, metaclass=HideNonPublicMeta):
+    pass

--- a/geoapi/tests/api_tests/test_projects_routes.py
+++ b/geoapi/tests/api_tests/test_projects_routes.py
@@ -13,6 +13,11 @@ def test_get_projects(test_client, projects_fixture):
     assert len(data) == 1
 
 
+def test_get_projects_not_allowed(test_client):
+    resp = test_client.get('/projects/')
+    assert resp.status_code == 403
+
+
 def test_get_projects_using_uuids(test_client, projects_fixture, projects_fixture2):
     requested_uuids = [str(projects_fixture2.uuid), str(projects_fixture.uuid)]
     u1 = db_session.query(User).get(1)

--- a/geoapi/tests/api_tests/test_projects_routes.py
+++ b/geoapi/tests/api_tests/test_projects_routes.py
@@ -211,6 +211,14 @@ def test_import_image_tapis(test_client, projects_fixture, import_file_from_agav
     assert resp.status_code == 200
 
 
+def test_get_point_clouds_listing(test_client, projects_fixture, point_cloud_fixture):
+    u1 = db_session.query(User).get(1)
+    resp = test_client.get('/projects/1/point-cloud/', headers={'x-jwt-assertion-test': u1.jwt})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+
+
 def test_get_point_cloud(test_client, projects_fixture, point_cloud_fixture):
     u1 = db_session.query(User).get(1)
     resp = test_client.get('/projects/1/point-cloud/1/', headers={'x-jwt-assertion-test': u1.jwt})

--- a/geoapi/tests/api_tests/test_public_projects_routes.py
+++ b/geoapi/tests/api_tests/test_public_projects_routes.py
@@ -1,0 +1,77 @@
+def test_get_project_using_single_uuid_unauthorized_guest(test_client, projects_fixture):
+    resp = test_client.get('/public-projects/',
+                           query_string='uuid={}'.format(projects_fixture.uuid))
+    assert resp.status_code == 403
+
+
+def test_get_public_project_using_single_uuid(test_client, public_projects_fixture):
+    resp = test_client.get('/public-projects/',
+                           query_string='uuid={}'.format(public_projects_fixture.uuid))
+    assert resp.status_code == 200
+
+
+def test_project_data_allow_public_access(test_client, public_projects_fixture):
+    resp = test_client.get('/public-projects/{}/'.format(public_projects_fixture.id))
+    assert resp.status_code == 200
+
+
+def test_put_project_not_found(test_client, projects_fixture):
+    data = {'name': "Renamed Project", 'description': "New Description", 'public': True}
+    resp = test_client.put(
+        '/public-projects/{}/'.format(projects_fixture),
+        json=data
+    )
+    assert resp.status_code == 404
+
+
+def test_delete_project_not_found(test_client, projects_fixture):
+    resp = test_client.delete('/public-projects/21/')
+    assert resp.status_code == 404
+
+
+def test_get_project_features_empty_public_access(test_client, public_projects_fixture):
+    resp = test_client.get('/public-projects/{}/features/'.format(public_projects_fixture.id))
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data['features']) == 0
+
+
+def test_get_project_features_single_feature_public_access(test_client, public_projects_fixture, feature_fixture):
+    resp = test_client.get('/public-projects/{}/features/'.format(public_projects_fixture.id))
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert len(data['features']) != 0
+
+
+def test_get_overlay_public_access(test_client, public_projects_fixture):
+    resp = test_client.get('/public-projects/1/overlays/')
+    assert resp.status_code == 200
+
+
+def test_get_point_cloud_public_access(test_client, public_projects_fixture, point_cloud_fixture):
+    resp = test_client.get('/public-projects/1/point-cloud/1/')
+    assert resp.status_code == 200
+
+
+def test_get_point_cloud_public_access(test_client, public_projects_fixture, point_cloud_fixture):
+    resp = test_client.get('/projects/1/point-cloud/1/')
+    assert resp.status_code == 200
+
+
+def test_post_feature_import_not_found(test_client, projects_fixture, import_file_from_agave_mock):
+    resp = test_client.post(
+        '/public-projects/1/features/files/import/',
+        json={"files": [{"system": "designsafe.storage.default", "path": "file.jpg"}]}
+    )
+    assert resp.status_code == 404
+
+
+def test_post_feature_not_found(test_client, projects_fixture, image_file_fixture):
+    resp = test_client.post(
+        '/public-projects/1/features/files/',
+        data={"file": image_file_fixture}
+    )
+    assert resp.status_code == 404
+
+# TODO test tile server
+

--- a/geoapi/tests/api_tests/test_public_projects_routes.py
+++ b/geoapi/tests/api_tests/test_public_projects_routes.py
@@ -26,7 +26,7 @@ def test_put_project_not_found(test_client, projects_fixture):
 
 def test_delete_project_not_found(test_client, projects_fixture):
     resp = test_client.delete('/public-projects/21/')
-    assert resp.status_code == 404
+    assert resp.status_code == 405
 
 
 def test_get_project_features_empty_public_access(test_client, public_projects_fixture):
@@ -48,13 +48,15 @@ def test_get_overlay_public_access(test_client, public_projects_fixture):
     assert resp.status_code == 200
 
 
+def test_get_point_clouds_listing(test_client, public_projects_fixture, point_cloud_fixture):
+    resp = test_client.get('/projects/1/point-cloud/')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+
+
 def test_get_point_cloud_public_access(test_client, public_projects_fixture, point_cloud_fixture):
     resp = test_client.get('/public-projects/1/point-cloud/1/')
-    assert resp.status_code == 200
-
-
-def test_get_point_cloud_public_access(test_client, public_projects_fixture, point_cloud_fixture):
-    resp = test_client.get('/projects/1/point-cloud/1/')
     assert resp.status_code == 200
 
 


### PR DESCRIPTION
## Overview: ##

Add /public-projects routs (a duplicate GETs in /projects) to be provided by WSO2 (auth_type:none) for guest users

## Related Jira tickets: ##

* [DES-1946](https://jira.tacc.utexas.edu/browse/DES-1946)

## Summary of Changes: ##
* Fix so that swagger.json can be provided.
* Return 403 for unauthed projects listing
* Provide project routes for public access

## Testing Steps: ##
1. see swagger/openapi definition (http://localhost:8888/swagger.json or on staging) and confirm that everything looks right for public-projects
2. testing staging environment that has been configured with auth type of None for these routes.

## Notes: ##
We need to test on staging environment using WS