### PR TITLE
Task/DES-1988: Delete saving file on export.

### DIFF
--- a/geoapi/services/projects.py
+++ b/geoapi/services/projects.py
@@ -11,7 +11,7 @@ from geoapi.services.users import UserService
 from geoapi.services.notifications import NotificationsService
 from geoapi.utils.agave import AgaveUtils, get_system_users
 from geoapi.utils.assets import get_project_asset_dir
-from geoapi.tasks.external_data import import_from_agave, delete_agave_file
+from geoapi.tasks.external_data import import_from_agave
 from geoapi.log import logging
 from geoapi.exceptions import ApiException, ObservableProjectAlreadyExists
 
@@ -105,16 +105,11 @@ class ProjectsService:
         Save a project UUID file to tapis
         :param user: User
         :param data: dict
-        :return: None
+        :param observable: bool
+        :project_id: int
+        :return: Project
         """
         proj = ProjectsService.get(project_id=project_id)
-
-        # If already has a saved file remove it
-        if proj.system_path is not None:
-            delete_agave_file.apply_async(args=[proj.system_id,
-                                                '{}/{}'.format(proj.system_path,
-                                                               proj.system_file),
-                                                user.id])
 
         path = data['path']
 
@@ -129,16 +124,6 @@ class ProjectsService:
         proj.system_file = file_name
         proj.system_id = data['system_id']
         db_session.commit()
-
-        file_content = {
-            'uuid': str(proj.uuid)
-        }
-
-        AgaveUtils(user.jwt).postFile(data['system_id'],
-                                      path,
-                                      file_name,
-                                      file_content
-                                      )
 
         return proj
 
@@ -307,10 +292,6 @@ class ProjectsService:
         db_session.delete(proj)
         db_session.commit()
 
-        if proj.system_path is not None:
-            delete_agave_file.apply_async(args=[proj.system_id,
-                                                proj.system_path + '/' + proj.system_file,
-                                                user.id])
         assets_folder = get_project_asset_dir(projectId)
         try:
             shutil.rmtree(assets_folder)

--- a/geoapi/services/projects.py
+++ b/geoapi/services/projects.py
@@ -102,7 +102,7 @@ class ProjectsService:
                observable: bool,
                project_id: int) -> Project:
         """
-        Save a project UUID file to tapis
+        Create a project
         :param user: User
         :param data: dict
         :param observable: bool

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -126,13 +126,6 @@ def _update_point_cloud_task(pointCloudId: int, description: str = None, status:
         db_session.rollback()
         raise
 
-
-@app.task(rate_limit="1/s")
-def delete_agave_file(system_id: str, system_path: str, userId: int):
-    user = db_session.query(User).get(userId)
-    AgaveUtils(user.jwt).deleteFile(system_id, system_path)
-
-
 @app.task(rate_limit="1/s")
 def import_point_clouds_from_agave(userId: int, files, pointCloudId: int):
     user = db_session.query(User).get(userId)

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -126,6 +126,7 @@ def _update_point_cloud_task(pointCloudId: int, description: str = None, status:
         db_session.rollback()
         raise
 
+
 @app.task(rate_limit="1/s")
 def import_point_clouds_from_agave(userId: int, files, pointCloudId: int):
     user = db_session.query(User).get(userId)

--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -131,57 +131,6 @@ class AgaveUtils:
             logger.error("Could not fetch file ({}/{}): {}".format(systemId, path, e))
             raise e
 
-    def postFile(self, systemId: str, path: str, file_name: str, file_content: dict) -> None:
-        """
-        Upload a file to agave
-        :param systemId: str
-        :param path (directory): str
-        :param file_name: str
-        :param file_content: dict
-        :return: None
-        """
-        url = quote('/files/media/system/{}/{}'.format(systemId, path))
-        try:
-            logger.info("Uploading to " + self.base_url + url)
-            tmp = NamedTemporaryFile(delete=True, mode="r+")
-            tmp.name = file_name
-            json.dump(file_content, tmp)
-            tmp.flush()
-            tmp.seek(0)
-            files = { 'fileToUpload': tmp }
-            with self.client.post(self.base_url + url,
-                                  verify=False,
-                                  files=files) as r:
-                if r.status_code > 400:
-                    tmp.close()
-                    raise ValueError("Could not post file ({}/{}/{}) status_code:{}".format(systemId,
-                                                                                            path,
-                                                                                            file_name,
-                                                                                            r.status_code))
-                tmp.close()
-        except Exception as e:
-            logger.error("Could not post file ({}/{}/{}): {}".format(systemId, path, file_name, e))
-            raise e
-
-    def deleteFile(self, systemId: str, path: str) -> None:
-        """
-        Delete an agave file
-        :param systemId: str
-        :param path (directory): str
-        :return: None
-        """
-        url = quote('/files/media/system/{}/{}'.format(systemId, path))
-        try:
-            logger.info("Deleting " + self.base_url + url)
-            with self.client.delete(self.base_url + url) as r:
-                if r.status_code > 400:
-                    raise ValueError("Could not delete file ({}/{}) status_code:{}".format(systemId,
-                                                                                           path,
-                                                                                           r.status_code))
-        except Exception as e:
-            logger.error("Could not delete file ({}/{}): {}".format(systemId, path, e))
-            raise e
-
 
 def service_account_client(tenant_id):
     try:


### PR DESCRIPTION
## Overview: ##
Removes saving files on export.
Related to TACC-Cloud/hazmapper#70, which moves the functionality to the frontend.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1988](https://jira.tacc.utexas.edu/browse/DES-1988)

## Summary of Changes: ##
Deleted `postFile`/`deleteFile` calls and definitions.

## Testing Steps: ##
1. Test with TACC-Cloud/hazmapper#70 to ensure that saving still work in the frontend.

## Notes: ##
