### PR TITLE
Use service account to download file

### DIFF
--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -128,7 +128,10 @@ class AgaveUtils:
                     if systemInfo["public"]:
                         logger.warn("As system is a public storage system for projects. we will use service "
                                     "account to get file".format(systemId, path))
-                        return self._get_file_using_service_account(systemId, path);
+                        return self._get_file_using_service_account(systemId, path)
+                    else:
+                        logger.warn("{}/{}.  System is not public so not trying "
+                                    "work-around for CS-169/DES-2084.".format(systemId, path))
                 if r.status_code > 400:
                     raise ValueError("Could not fetch file ({}/{}) status_code:{}".format(systemId,
                                                                                           path,


### PR DESCRIPTION
## Overview: ##

This is a workaround for bug documented in
* https://jira.tacc.utexas.edu/browse/CS-169
* https://jira.tacc.utexas.edu/browse/DES-2084

Sometimes a 403 is returned by tapis sometimes using the prod tenant
instead of the designsafe tenant. The workaround is to use the service
account on the designsafe tenant (which somehow "fixes" the problem in case someone tries to access the file again later)

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2084](https://jira.tacc.utexas.edu/browse/DES-2084)

## Testing Steps: ##
1.  Using main branch (or prod or staging)
2. Try to import Photo 262_ARL.jpg from "/PRJ-2714/Data Sets by Location/Guanica Buildings/Images/Geotagged Images/”
3. It should fail due to 403
4. Use this PR's branch to do step 2
5. It should work and you should see some warnings in the logs saying that we are using the service account
6. Try again but this time it should just work without using the service account 🤷  as if we download it once on DS tenant then it "fixes" things.    So if you need to retest things, we'll need to find another file where this bug occurs.

## Notes: ##

I was thinking originally as doing a file listing by the user to check if they have access.  I didn't do that. Instead, I just check if the system was `public`.  So far, we've only seen this on published projects so hopefully it just occurs there.  If occurs in private systems, we'll see that in the logs now and improve our work-around.
