### PR TITLE
Task/DES-2177 do not scrape trash files

### DIFF
--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -224,7 +224,7 @@ def import_from_agave(tenant_id: str, userId: int, systemId: str, path: str, pro
     files_in_directory = listing[1:]
     filenames_in_directory = [str(f.path) for f in files_in_directory]
     for item in files_in_directory:
-        if item.type == "dir":
+        if item.type == "dir" and not str(item.path).endswith("/.Trash"):
             import_from_agave(tenant_id, userId, systemId, item.path, projectId)
         # skip any junk files that are not allowed
         if item.path.suffix.lower().lstrip('.') not in FeaturesService.ALLOWED_EXTENSIONS:


### PR DESCRIPTION
## Overview: ##

Do not import files under .Trash when scraping/syncing observable projects 

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2177](https://jira.tacc.utexas.edu/browse/DES-2177)

## Summary of Changes: ##

## Testing Steps: ##
Manual
1. Create a project that syncs from [PRJ-3413 | Observable-Project-Test-Example](https://www.designsafe-ci.org/data/browser/projects/592149480076612076-242ac118-0001-012/)
2. Ensure that files in .Trash are not imported but that other files are

Unit test
1. Run unit tests (note: `-m worker`)
