### PR TITLE
Task/DES-2216: Use description for point cloud asset name instead of ID.

### DIFF
--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -6,6 +6,7 @@ from enum import Enum
 import json
 import time
 import datetime
+from celery import uuid as celery_uuid
 
 from geoapi.celery_app import app
 from geoapi.exceptions import InvalidCoordinateReferenceSystem, MissingServiceAccount

--- a/geoapi/tasks/lidar.py
+++ b/geoapi/tasks/lidar.py
@@ -125,6 +125,7 @@ def convert_to_potree(self, pointCloudId: int) -> None:
             uuid=asset_uuid,
             asset_type="point_cloud",
             path=get_asset_relative_path(asset_path),
+            display_path=point_cloud.description,
             feature=feature
         )
         feature.assets.append(fa)


### PR DESCRIPTION
## Overview: ##
Use `point_cloud`'s `description` instead of the `feature`'s `id`.
Also, fix bug in `tasks/lidar.py` where `celery_uuid` is not imported.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2216](https://jira.tacc.utexas.edu/browse/DES-2216)

## Summary of Changes: ##

## Testing Steps: ##
1. Ensure the `description` of `point_cloud` is being used as asset name in `asset-panel`

## Notes: ##
Long-term I think we could have the private feature property to contain this information.
However, I think this is ok because we don't lose `description` data.
