### PR TITLE
task/DES-2211: Increase memory limit for worker pods

### DIFF
--- a/kube/geoapi.yaml
+++ b/kube/geoapi.yaml
@@ -301,7 +301,7 @@ spec:
           requests:
             memory: '3G'
           limits:
-            memory: '8G'
+            memory: '100G'
         volumeMounts:
         - mountPath: /assets
           name: assets


### PR DESCRIPTION
## Overview: ##

Bump worker memory to 100GB. 

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2211](https://jira.tacc.utexas.edu/browse/DES-2211)

## Testing Steps: ##
1.  Probably best to test later in the staging environment.

