### PR TITLE
Task/DES-2236 add retry attempts to file getting

### DIFF
--- a/geoapi/tests/utils_tests/test_agave.py
+++ b/geoapi/tests/utils_tests/test_agave.py
@@ -1,6 +1,7 @@
 import pytest
+from unittest.mock import patch
 from geoapi.exceptions import MissingServiceAccount
-from geoapi.utils.agave import service_account_client
+from geoapi.utils.agave import service_account_client, AgaveUtils, AgaveFileGetError
 
 
 def test_service_account_client():
@@ -14,3 +15,41 @@ def test_service_account_client():
 def test_service_account_client_missing():
     with pytest.raises(MissingServiceAccount):
         service_account_client("non_existing_tenant")
+
+
+@pytest.fixture(scope="function")
+def retry_sleep_seconds_mock():
+    with patch('geoapi.utils.agave.SLEEP_SECONDS_BETWEEN_RETRY', 0) as sleep_mock:
+        yield sleep_mock
+
+
+def test_get_file(requests_mock, retry_sleep_seconds_mock, image_file_fixture):
+    system = "system"
+    path = "path"
+    requests_mock.get(AgaveUtils.BASE_URL + f"/files/media/system/{system}/{path}",
+                      status_code=200,
+                      body=image_file_fixture)
+    agave_utils = AgaveUtils()
+    agave_utils.getFile(system, path)
+
+
+def test_get_file_retry_after_first_attempt(requests_mock, retry_sleep_seconds_mock, image_file_fixture):
+    system = "system"
+    path = "path"
+    bad_response = [{'status_code': 500} for _ in range(2)]
+    bad_response.append({"status_code": 200, "body": image_file_fixture})
+    requests_mock.get(AgaveUtils.BASE_URL + f"/files/media/system/{system}/{path}",
+                      bad_response)
+    agave_utils = AgaveUtils()
+    agave_utils.getFile(system, path)
+
+
+def test_get_file_retry_too_many_attempts(requests_mock, retry_sleep_seconds_mock):
+    system = "system"
+    path = "path"
+    bad_response = [{'status_code': 500} for _ in range(10)]
+    requests_mock.get(AgaveUtils.BASE_URL + f"/files/media/system/{system}/{path}",
+                      bad_response)
+    agave_utils = AgaveUtils()
+    with pytest.raises(AgaveFileGetError):
+        agave_utils.getFile(system, path)

--- a/geoapi/tests/utils_tests/test_agave.py
+++ b/geoapi/tests/utils_tests/test_agave.py
@@ -36,10 +36,9 @@ def test_get_file(requests_mock, retry_sleep_seconds_mock, image_file_fixture):
 def test_get_file_retry_after_first_attempt(requests_mock, retry_sleep_seconds_mock, image_file_fixture):
     system = "system"
     path = "path"
-    bad_response = [{'status_code': 500} for _ in range(2)]
-    bad_response.append({"status_code": 200, "body": image_file_fixture})
-    requests_mock.get(AgaveUtils.BASE_URL + f"/files/media/system/{system}/{path}",
-                      bad_response)
+    responses = [{'status_code': 500} for _ in range(2)]
+    responses.append({"status_code": 200, "body": image_file_fixture})
+    requests_mock.get(AgaveUtils.BASE_URL + f"/files/media/system/{system}/{path}", responses)
     agave_utils = AgaveUtils()
     agave_utils.getFile(system, path)
 

--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -128,7 +128,7 @@ class AgaveUtils:
         out = {k: v for d in results for k, v in d.items()}
         return out
 
-    def _get_file(self, systemId: str, path: str, use_service_account: bool=False) -> IO:
+    def _get_file(self, systemId: str, path: str, use_service_account: bool = False) -> IO:
         """
         Get file
 
@@ -209,7 +209,6 @@ class AgaveUtils:
         msg = f"Could not fetch file and no longer retrying. (could be CS-196): ({systemId}/{path})"
         logger.exception(msg)
         raise AgaveFileGetError(msg)
-
 
     def getRawFileToPath(self, systemId: str, fromPath: str, toPath: str):
         url = quote('/files/media/system/{}/{}'.format(systemId, fromPath))

--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -17,6 +17,8 @@ from geoapi.exceptions import MissingServiceAccount
 
 logger = logging.getLogger(__name__)
 
+SLEEP_SECONDS_BETWEEN_RETRY = 2
+
 
 class AgaveFileGetError(Exception):
     '''' Unable to fetch file from agave
@@ -196,7 +198,7 @@ class AgaveUtils:
                 allowed_attempts = allowed_attempts - 1
                 logger.error(f"File fetching failed but is retryable (i.e. could be CS-1960): ({systemId}/{path}) ")
                 if allowed_attempts > 0:
-                    time.sleep(2)
+                    time.sleep(SLEEP_SECONDS_BETWEEN_RETRY)
                 continue
             except Exception as e:
                 logger.exception(f"Could not fetch file and did not attempt to retry: ({systemId}/{path})")

--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -179,9 +179,9 @@ class AgaveUtils:
         """
         Download a file from tapis
 
-        We attempt to get the file multiple times in case tapis is having issues (like if we see CS-196
-        where we get a 500 to hitting ssh limits via tapis or if the file is 0 bytes ) but eventually
-        raise AgaveFileGetError if we can't get the file.
+        We attempt to get the file multiple times in case tapis is having issues (like if we see CS-196/DES-2236
+        where tapis hits an ssh limits and then we get a a 500 or a file with 0 bytes). Eventually
+        we will raise AgaveFileGetError if we can't get the file.
 
         :raises
             AgaveFileGetError: Raised if unable to get file via tapis.
@@ -196,7 +196,7 @@ class AgaveUtils:
                 return self._get_file(systemId, path)
             except RetryableTapisFileError:
                 allowed_attempts = allowed_attempts - 1
-                logger.error(f"File fetching failed but is retryable (i.e. could be CS-1960): ({systemId}/{path}) ")
+                logger.error(f"File fetching failed but is retryable (i.e. could be CS-196): ({systemId}/{path}) ")
                 if allowed_attempts > 0:
                     time.sleep(SLEEP_SECONDS_BETWEEN_RETRY)
                 continue

--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -1,4 +1,6 @@
 import shutil
+import os
+import time
 from tempfile import NamedTemporaryFile
 
 import requests
@@ -19,6 +21,15 @@ logger = logging.getLogger(__name__)
 class AgaveFileGetError(Exception):
     '''' Unable to fetch file from agave
     '''
+    pass
+
+
+class RetryableTapisFileError(Exception):
+    """ Tapis file errors which are known to possibly work if retried.
+
+        This is raised if we know its an error that we can re-attempt to get. Note that if we
+        try multiple times and it still doesn't work, we then raise a AgaveFileGetError exception
+    """
     pass
 
 
@@ -115,42 +126,84 @@ class AgaveUtils:
         out = {k: v for d in results for k, v in d.items()}
         return out
 
+    def _get_file(self, systemId: str, path: str) -> IO:
+        """
+        Get
+
+        :raises
+            RetryableTapisFileError: If tapis error occurs where its possible to retry
+            AgaveFileGetError: Raised if tapis error occurs and uncertain if we can retry
+
+        :param systemId:
+        :param path:
+        :return:
+        """
+        url = quote('/files/media/system/{}/{}'.format(systemId, path))
+
+        with self.client.get(self.base_url + url, stream=True) as r:
+            if r.status_code == 403:
+                # This is a workaround for bug documented in https://jira.tacc.utexas.edu/browse/CS-169
+                # and in https://jira.tacc.utexas.edu/browse/DES-2084 where sometimes a 403 is returned by tapis
+                # for some files.
+                logger.warning(f"Could not fetch file ({systemId}/{path}) due to unexpected 403. Possibly CS-169/DES-2084.")
+                systemInfo = self.systemsGet(systemId)
+                if systemInfo["public"]:
+                    logger.warning("As system is a public storage system for projects. we will use service "
+                                   "account to get file: {}/{}".format(systemId, path))
+                    return self._get_file_using_service_account(systemId, path)
+                else:
+                    logger.warning(f"System is not public so not trying work-around for CS-169/DES-2084: {systemId}/{path}")
+            if r.status_code > 400:
+                if r.status_code == 500:
+                    logger.warning(f"Fetch file ({systemId}/{path}) but got 500 {r}: {r.content};"
+                                   f"500 is possibly due to CS-196/DES-2236.")
+                    raise RetryableTapisFileError
+
+                raise AgaveFileGetError("Could not fetch file ({}/{}) status_code:{} exception:".format(systemId,
+                                                                                                        path,
+                                                                                                        r.status_code))
+            tmpFile = NamedTemporaryFile()
+            for chunk in r.iter_content(1024 * 1024):
+                tmpFile.write(chunk)
+            tmpFile.seek(0)
+
+            if os.path.getsize(tmpFile.name) < 1:
+                logger.warning(f"Fetch file ({systemId}/{path}) but is empty. "
+                               f"Either file is really empty or possibly due to CS-196/DES-2236.")
+                raise RetryableTapisFileError
+        return tmpFile
+
     def getFile(self, systemId: str, path: str) -> IO:
         """
-        Download a file from agave
+        Download a file from tapis
+
+        We attempt to get the file multiple times in case tapis is having issues (like if we see CS-196
+        where we get a 500 to hitting ssh limits via tapis or if the file is 0 bytes ) but eventually
+        raise AgaveFileGetError if we can't get the file.
+
+        :raises
+            AgaveFileGetError: Raised if unable to get file via tapis.
+
         :param systemId: str
         :param path: str
         :return: temporary file
         """
-        url = quote('/files/media/system/{}/{}'.format(systemId, path))
-        try:
-            with self.client.get(self.base_url + url, stream=True) as r:
-                if r.status_code == 403:
-                    # This is a workaround for bug documented in https://jira.tacc.utexas.edu/browse/CS-169
-                    # and in https://jira.tacc.utexas.edu/browse/DES-2084 where sometimes a 403 is returned by tapis
-                    # for some files.
-                    logger.warn("Could not fetch file ({}/{}) due to unexpected 403. "
-                                "Possibly CS-169/DES-2084.".format(systemId, path))
-                    systemInfo = self.systemsGet(systemId)
-                    if systemInfo["public"]:
-                        logger.warn("As system is a public storage system for projects. we will use service "
-                                    "account to get file: {}/{}".format(systemId, path))
-                        return self._get_file_using_service_account(systemId, path)
-                    else:
-                        logger.warn("{}/{}.  System is not public so not trying "
-                                    "work-around for CS-169/DES-2084.".format(systemId, path))
-                if r.status_code > 400:
-                    raise AgaveFileGetError("Could not fetch file ({}/{}) status_code:{}".format(systemId,
-                                                                                                 path,
-                                                                                                 r.status_code))
-                tmpFile = NamedTemporaryFile()
-                for chunk in r.iter_content(1024 * 1024):
-                    tmpFile.write(chunk)
-                tmpFile.seek(0)
-                return tmpFile
-        except Exception as e:
-            logger.error("Could not fetch file ({}/{}): {}".format(systemId, path, e))
-            raise e
+        allowed_attempts = 5
+        while allowed_attempts > 0:
+            try:
+                return self._get_file(systemId, path)
+            except RetryableTapisFileError:
+                allowed_attempts = allowed_attempts - 1
+                logger.error(f"File fetching failed but is retryable (i.e. could be CS-1960): ({systemId}/{path}) ")
+                if allowed_attempts > 0:
+                    time.sleep(2)
+                continue
+            except Exception as e:
+                logger.exception(f"Could not fetch file and did not attempt to retry: ({systemId}/{path})")
+                raise e
+        msg = f"Could not fetch file and no longer retrying. (could be CS-196): ({systemId}/{path})"
+        logger.exception(msg)
+        raise AgaveFileGetError(msg)
 
     def _get_file_using_service_account(self, systemId: str, path: str) -> IO:
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,6 +68,7 @@ python-editor==1.0.4
 pytz==2019.3
 regex==2020.2.20
 requests==2.23.0
+requests-mock==3.8.2
 requests-toolbelt==0.9.1
 Shapely==1.7.0
 six==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,7 +68,7 @@ python-editor==1.0.4
 pytz==2019.3
 regex==2020.2.20
 requests==2.23.0
-requests-mock==3.8.2
+requests-mock==1.9.3
 requests-toolbelt==0.9.1
 Shapely==1.7.0
 six==1.14.0


### PR DESCRIPTION
## Overview: ##

Add retry attempts when getting files

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2236](https://jira.tacc.utexas.edu/browse/DES-2236)

## Summary of Changes: ##

## Testing Steps: ##
1. Hard to recreate locally.  You could review code or I can provide a script provides some stress testing of downloading to overwhelm TAPIS.

## Notes: ##

- [x] add requests_mock package requirement
- [x] ~evaluate~ remove/replace overlapping _get_file_using_service_account ~for follow-up PR~
- [x] evaluate overlapping getRawFileToPath for follow-up PR  (note https://requests.readthedocs.io/en/latest/user/quickstart/#raw-response-content says iter_content is preferred but if results are the same we should consider combining them.  Ian and I were wondering if the issues seen previously were due to DES-2236 and the empty files). update: added follow-on Jira issue for this quarter: https://jira.tacc.utexas.edu/browse/DES-2286
