### PR TITLE
Task/DES-2231 handle potential listing errors

### DIFF
--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -2,7 +2,7 @@ from flask import request, abort
 from flask_restplus import Resource, Namespace, fields, inputs
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
-from geoapi.log import logging
+from geoapi.log import logger
 from geoapi.schemas import FeatureSchema
 from geoapi.services.features import FeaturesService
 from geoapi.services.streetview import StreetviewService
@@ -14,8 +14,6 @@ from geoapi.utils.decorators import (jwt_decoder, project_permissions_allow_publ
                                      project_point_cloud_not_processing, check_access_and_get_project, is_anonymous,
                                      not_anonymous, project_admin_or_creator_permissions)
 
-
-logger = logging.getLogger(__name__)
 
 api = Namespace('projects', decorators=[jwt_decoder])
 

--- a/geoapi/services/projects.py
+++ b/geoapi/services/projects.py
@@ -12,10 +12,8 @@ from geoapi.utils.agave import AgaveUtils, get_system_users
 from geoapi.utils.assets import get_project_asset_dir
 from geoapi.utils.users import is_anonymous
 from geoapi.tasks.external_data import import_from_agave
-from geoapi.log import logging
+from geoapi.log import logger
 from geoapi.exceptions import ApiException, ObservableProjectAlreadyExists
-
-logger = logging.getLogger(__name__)
 
 
 class ProjectsService:

--- a/geoapi/services/projects.py
+++ b/geoapi/services/projects.py
@@ -272,6 +272,7 @@ class ProjectsService:
         :return:
         """
         db_session.query(Project).filter(Project.id == projectId).delete()
+        db_session.commit()
 
         assets_folder = get_project_asset_dir(projectId)
         try:

--- a/geoapi/tests/api_tests/test_projects_service.py
+++ b/geoapi/tests/api_tests/test_projects_service.py
@@ -4,6 +4,7 @@ from geoapi.db import db_session
 
 from geoapi.services.projects import ProjectsService
 from geoapi.models import User
+from geoapi.models.project import Project, ProjectUser
 from geoapi.exceptions import ObservableProjectAlreadyExists
 
 
@@ -20,6 +21,12 @@ def test_create_project():
     assert len(proj.users) == 1
     assert proj.name == "test name"
     assert proj.description == "test description"
+
+
+def test_delete_project(projects_fixture, user1):
+    ProjectsService.delete(user1, projects_fixture.id)
+    projects = db_session.query(Project).all()
+    assert projects == []
 
 
 def test_create_observable_project(userdata,

--- a/geoapi/tests/api_tests/test_projects_service.py
+++ b/geoapi/tests/api_tests/test_projects_service.py
@@ -4,7 +4,7 @@ from geoapi.db import db_session
 
 from geoapi.services.projects import ProjectsService
 from geoapi.models import User
-from geoapi.models.project import Project, ProjectUser
+from geoapi.models.project import Project
 from geoapi.exceptions import ObservableProjectAlreadyExists
 
 

--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -22,6 +22,12 @@ logger = logging.getLogger(__name__)
 SLEEP_SECONDS_BETWEEN_RETRY = 2
 
 
+class AgaveListingError(Exception):
+    '''' Unable to list directory from agave
+    '''
+    pass
+
+
 class AgaveFileGetError(Exception):
     '''' Unable to fetch file from agave
     '''
@@ -113,6 +119,9 @@ class AgaveUtils:
     def listing(self, systemId: str, path: str) -> List[AgaveFileListing]:
         url = quote('/files/listings/system/{}/{}?limit=10000'.format(systemId, path))
         resp = self.get(url)
+        if resp.status_code != 200:
+            raise AgaveListingError(f"Unable to perform files listing of {systemId}/{path}. "
+                                    f"Status code: {resp.status_code}")
         listing = resp.json()
         out = [AgaveFileListing(d) for d in listing["result"]]
         return out


### PR DESCRIPTION
## Overview: ##

This PR fixes things related to DES-2231:
* Handle when directory listing fails
* Refactor refresh so that it catches any unhandled error when importing a single project but **now* continue with rest of projects (Before, we just stopped instead of working on the rest of the projects)

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2231](https://jira.tacc.utexas.edu/browse/DES-2231)

## Summary of Changes: ##

## Testing Steps: ##
1. Use "PRJ-3413 | Observable-Project-Test-Example" (i.e. https://www.designsafe-ci.org/data/browser/projects/592149480076612076-242ac118-0001-012/ ) for testing. This project has a folder with a space at the end which causes a tapis file-listing to fail.
2. Create a map project that observes that project.
3. Check that import can occur even though one of the subfolders fails to list (there should be one folder listing that fails and then some images loaded but also one image should fail which is unrelated to this PR)
4. Check code logic to see that this wouldn't impact any other observable projects (e350f84b0086879041fce196ec9046908680c74b allows us to continue to next project)

## Notes: ##
