### PR TITLE
task/DES-2374: fix service account url for getting files

### DIFF
--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -157,8 +157,9 @@ class AgaveUtils:
         url = quote('/files/media/system/{}/{}'.format(systemId, path))
 
         client = service_account_client("designsafe").client if use_service_account else self.client
+        base_url = service_account_client("designsafe").base_url if use_service_account else self.base_url
 
-        with client.get(self.base_url + url, stream=True) as r:
+        with client.get(base_url + url, stream=True) as r:
             if r.status_code == 403 and not use_service_account:
                 # This is a workaround for bug documented in https://jira.tacc.utexas.edu/browse/CS-169
                 # and in https://jira.tacc.utexas.edu/browse/DES-2084 where sometimes a 403 is returned by tapis


### PR DESCRIPTION
## Overview: ##

Fix regression (caused by #99)  where the service account was using the wrong URL for getting files.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2374](https://jira.tacc.utexas.edu/browse/DES-2374)

## Testing Steps: ##
1. On prod/staging, try to import a file on My Data and confirms it fails
2. Use this branch locally, and then try to import one of those failing files.

