### PR TITLE
hotfix/fix poetry install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -q && apt-get install -q -y \
 ENV POETRY_VERSION=1.1.13
 ENV POETRY_HOME=/opt/poetry
 ENV PATH="$POETRY_HOME/bin:$PATH"
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+RUN curl -sSL https://install.python-poetry.org | python3 -
 RUN poetry config virtualenvs.create false
 COPY pyproject.toml poetry.lock ./
 RUN poetry install


### PR DESCRIPTION
## Overview: ##

Fix poetry install

Script we installed poetry is no longer there. See https://jenkins01.tacc.utexas.edu/view/Hazmapper+Geoapi/job/Geoapi%20(build%20image)/74/console

```
Step 6/13 : RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
 ---> Running in 8002b9663576
[91m  File "<stdin>", line 1
    404: Not Found
    ^
```
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

