### PR TITLE
task/DES-abc: Move project asset directory deletion to celery task

### DIFF
--- a/geoapi/tasks/__init__.py
+++ b/geoapi/tasks/__init__.py
@@ -1,3 +1,4 @@
 from geoapi.tasks.lidar import convert_to_potree
 from geoapi.tasks.external_data import import_file_from_agave, import_from_agave, refresh_observable_projects
 from geoapi.tasks.streetview import publish, from_tapis_to_streetview, process_streetview_sequences
+from geoapi.tasks.projects import remove_project_assets

--- a/geoapi/tasks/projects.py
+++ b/geoapi/tasks/projects.py
@@ -1,0 +1,22 @@
+from geoapi.celery_app import app
+from geoapi.utils.assets import get_project_asset_dir
+from geoapi.log import logger
+import shutil
+
+
+@app.task()
+def remove_project_assets(project_id):
+    """
+    Remove all assets associated with a project.
+
+    The directory containing that project's assets will be deleted.
+
+    """
+    logger.info(f"Deleting project:{project_id} started")
+    assets_folder = get_project_asset_dir(project_id)
+    try:
+        shutil.rmtree(assets_folder)
+        logger.info(f"Deleting project:{project_id} finished")
+    except FileNotFoundError:
+        logger.info(f"Deleting project:{project_id} completed but caught FileNotFoundError")
+        pass

--- a/geoapi/tests/api_tests/test_projects_service.py
+++ b/geoapi/tests/api_tests/test_projects_service.py
@@ -23,7 +23,7 @@ def test_create_project():
     assert proj.description == "test description"
 
 
-def test_delete_project(projects_fixture, user1):
+def test_delete_project(projects_fixture, remove_project_assets_mock, user1):
     ProjectsService.delete(user1, projects_fixture.id)
     projects = db_session.query(Project).all()
     assert projects == []

--- a/geoapi/tests/conftest.py
+++ b/geoapi/tests/conftest.py
@@ -457,6 +457,20 @@ def get_system_users_mock(userdata):
 
 
 @pytest.fixture(scope="function")
+def remove_project_assets_mock():
+    # we mock method so that we execute it synchronously (and not as a celery task on worker)
+    # when testing some routes
+    with patch('geoapi.services.projects.remove_project_assets') as mock_remove_project:
+        from geoapi.tasks.projects import remove_project_assets
+
+        def remove(args):
+            remove_project_assets(project_id=args[0])
+
+        mock_remove_project.apply_async.side_effect = remove
+        yield mock_remove_project
+
+
+@pytest.fixture(scope="function")
 def tile_server_ini_file_fixture():
     home = os.path.dirname(__file__)
     with open(os.path.join(home, 'fixtures/metadata.ini'), 'rb') as f:


### PR DESCRIPTION
## Overview: ##

Moving project assets deletion to celery

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-9999](https://jira.tacc.utexas.edu/browse/DES-9999)

## Testing Steps: ##
1.  Do a project deletion and confirm that the project is deleted and done in a celery task

## Notes ##


**Background**:

The deletion work from the route should be moved to celery as it can take awhile (especially with poetry pointcloud files in a project) **but** it seems to cause a worse problem where just 4 project deletions can block the 4 workers in gunicorn.  It looks like it is something like this issue:  https://www.aboutwayfair.com/tech-innovation/blocking-io-in-gunicorn-gevent-workers  (in our case something in `shutil.rmtree` is blocking IO that gevent can't handle and blocks the workers 🤷‍♂️ ). (in addition to gunicorn docs, I found this overview helpful https://luis-sena.medium.com/gunicorn-worker-types-youre-probably-using-them-wrong-381239e13594)