### PR TITLE
task/fix handling of missing image geolocation

### DIFF
--- a/geoapi/services/images.py
+++ b/geoapi/services/images.py
@@ -56,7 +56,6 @@ class ImageService:
         imdata.coordinates = exif_loc
         return imdata
 
-
     @staticmethod
     def resizeImage(fileObj: IO) -> ImageData:
 

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -103,6 +103,11 @@ def get_additional_files(systemId: str, path: str, client, available_files=None)
 
 @app.task(rate_limit="1/s")
 def import_file_from_agave(userId: int, systemId: str, path: str, projectId: int):
+    """
+    Import file from TAPIS system
+
+    Note: all geolocation information is expected to be embedded in the imported file.
+    """
     user = db_session.query(User).get(userId)
     client = AgaveUtils(user.jwt)
     try:

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -224,6 +224,20 @@ def import_point_clouds_from_agave(userId: int, files, pointCloudId: int):
 
 @app.task(rate_limit="5/s")
 def import_from_agave(tenant_id: str, userId: int, systemId: str, path: str, projectId: int):
+    """
+    Recursively import files from a system/path.
+
+    If file has already been imported (i.e. during a previously call), we don't re-import it. Likewise,
+    if we have previously failed at importing a file, we do not retry to import the file (unless it was an error like
+    file-access where it makes sense to retry at a later time).
+
+    Files located in /Rapp folder (i.e. created by the RAPP app) are handled differently as their location data is not
+    contained in specific-file-format meta data (e.g. exif for images) but instead the location is stored in Tapis
+    metadata.
+
+    This method is called by refresh_observable_projects()
+    """
+
     user = db_session.query(User).get(userId)
     client = AgaveUtils(user.jwt)
     logger.info("Importing for project:{} directory:{}/{} for user:{}".format(projectId,

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -101,7 +101,7 @@ def get_additional_files(systemId: str, path: str, client, available_files=None)
     return additional_files
 
 
-@app.task(rate_limit="1/s")
+@app.task(rate_limit="10/s")
 def import_file_from_agave(userId: int, systemId: str, path: str, projectId: int):
     """
     Import file from TAPIS system

--- a/geoapi/tests/services/test_image_service.py
+++ b/geoapi/tests/services/test_image_service.py
@@ -3,6 +3,7 @@ from geoapi.exceptions import InvalidEXIFData
 from PIL import Image, ImageChops
 import pytest
 
+
 def test_image_service_rotations(flipped_image_fixture, corrected_image_fixture):
     imdata = ImageService.processImage(flipped_image_fixture)
     imdata.resized.save("/tmp/test_it_is_rotated.jpg")

--- a/geoapi/tests/services/test_image_service.py
+++ b/geoapi/tests/services/test_image_service.py
@@ -1,6 +1,7 @@
 from geoapi.services.images import ImageService, get_exif_location
+from geoapi.exceptions import InvalidEXIFData
 from PIL import Image, ImageChops
-
+import pytest
 
 def test_image_service_rotations(flipped_image_fixture, corrected_image_fixture):
     imdata = ImageService.processImage(flipped_image_fixture)
@@ -28,6 +29,16 @@ def test_get_exif_location(image_file_fixture):
     assert coordinates == (-80.78037499999999, 32.61850555555556)
 
 
+def test_get_exif_location_missing(image_file_no_location_fixture):
+    with pytest.raises(InvalidEXIFData):
+        get_exif_location(image_file_no_location_fixture)
+
+
 def test_process_image(image_file_fixture):
     imdata = ImageService.processImage(image_file_fixture)
     assert imdata.coordinates == (-80.78037499999999, 32.61850555555556)
+
+
+def test_process_image_location_missing(image_file_no_location_fixture):
+    with pytest.raises(InvalidEXIFData):
+        ImageService.processImage(image_file_no_location_fixture)


### PR DESCRIPTION
## Overview: ##

This PR:
* fixes handling of image's geolocation checking that was probably altered by updated python packages in  #97 
* Increase rate of file importing
* improve a docstr

## PR Status: ##

* [X] Ready.


## Related Jira tickets: ##

[DES-2420](https://jira.tacc.utexas.edu/browse/DES-2420)

## Testing Steps: ##
1. Import multiple files at one to test rate of file importing
2. Test importing of images that are missing geolocaiton
