### PR TITLE
Use ubuntu-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Run flake8
         run: flake8 geoapi
   Geoapi_Unit_Tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       APP_ENV: testing
       DB_HOST: localhost
@@ -60,7 +60,7 @@ jobs:
     - name: Run server-side unit tests
       run: poetry run pytest
   Workers_Unit_Tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: mdillon/postgis:11-alpine


### PR DESCRIPTION
## Overview: ##

Ubuntu 18.04 runner is deprecated ( https://github.com/actions/runner-images/pull/7388 ) as noted in [WG-29](https://jira.tacc.utexas.edu/browse/WG-29).  Bumping runner to ubuntu-latest (22.04)

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-29](https://jira.tacc.utexas.edu/browse/WG-29)

## Testing Steps: ##
1. Check that CI is running
