### PR TITLE
Task/WG-66-and-WG-36: fix path to mapillary tools and improve getting files from tapis

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,5 @@ exclude =
     geoapi/schemas/__init__.py
     # Files below are tied with https://jira.tacc.utexas.edu/browse/DES-2267
     geoapi/initdb.py
-    geoapi/tasks/streetview.py  
     geoapi/utils/streetview.py
     geoapi/services/streetview.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,9 @@ jobs:
       with:
         python-version: 3.9
     - name: Install ffmpeg
-      run: sudo apt-get install -y ffmpeg
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ffmpeg
     - name: Setup Poetry
       uses: abatilo/actions-poetry@v2.0.0
       with:

--- a/geoapi/settings.py
+++ b/geoapi/settings.py
@@ -44,6 +44,7 @@ class TestingConfig(Config):
     DB_PASSWD = 'dev'
     DB_HOST = os.environ.get('DB_HOST', 'postgres')
     TESTING = True
+    STREETVIEW_DIR = os.environ.get('STREETVIEW_DIR', '/tmp/streetview')
     ASSETS_BASE_DIR = '/tmp'
     TENANT = "{\"DESIGNSAFE\": {\"service_account_token\": \"ABCDEFG12344\"}," \
              " \"TEST\": {\"service_account_token\": \"ABCDEFG12344\"}  }"

--- a/geoapi/tasks/streetview.py
+++ b/geoapi/tasks/streetview.py
@@ -84,6 +84,13 @@ def clean_session(streetview_instance: StreetviewInstance,
 
 
 def _from_tapis(user: User, task_uuid: UUID, systemId: str, path: str):
+    """
+    Get files from tapis and place in a temporary streetview directory
+    :param user: User
+    :param task_uuid: UUID
+    :param systemId: str
+    :param path: str
+    """
     client = AgaveUtils(user.jwt)
     listing = client.listing(systemId, path)
     files_in_directory = listing[1:]

--- a/geoapi/tasks/streetview.py
+++ b/geoapi/tasks/streetview.py
@@ -129,7 +129,7 @@ def _from_tapis(user: User, task_uuid: UUID, systemId: str, path: str):
             done_files -= 1
             error_message = "Could not import file from agave: {} :: {}, {}" \
                 .format(systemId, path, e)
-            logger.error(error_message)
+            logger.exception(error_message)
             raise Exception(error_message)
 
     if len(img_list) == 0:

--- a/geoapi/tasks/streetview.py
+++ b/geoapi/tasks/streetview.py
@@ -107,6 +107,7 @@ def _from_tapis(user: User, task_uuid: UUID, systemId: str, path: str):
     done_files = 0
     files_length = len(files_in_directory)
 
+    # TODO https://jira.tacc.utexas.edu/browse/WG-94 get multiple files at the same time
     for item in files_in_directory:
         if item.type == "dir":
             continue

--- a/geoapi/tasks/streetview.py
+++ b/geoapi/tasks/streetview.py
@@ -377,6 +377,6 @@ def convert_streetview_sequence_to_feature(self, projectId, sequenceId, token):
     try:
         db_session.add(feature)
         db_session.commit()
-    except:
+    except Exception:
         db_session.rollback()
         raise

--- a/geoapi/tasks/streetview.py
+++ b/geoapi/tasks/streetview.py
@@ -108,7 +108,7 @@ def _from_tapis(user: User, task_uuid: UUID, systemId: str, path: str, organizat
         try:
             img_name = os.path.join(str(base_filepath), Path(item.path).name)
             img_list.append(img_name)
-            client.getRawFileToPath(systemId, item.path, img_name)
+            client.get_file_to_path(systemId, item.path, img_name)
 
             done_files += 1
 

--- a/geoapi/tasks/streetview.py
+++ b/geoapi/tasks/streetview.py
@@ -14,8 +14,7 @@ from geoalchemy2.shape import from_shape
 from shapely.geometry import Point, LineString
 
 from geoapi.celery_app import app
-from geoapi.exceptions import (ApiException,
-                               StreetviewAuthException,
+from geoapi.exceptions import (StreetviewAuthException,
                                StreetviewLimitException,
                                StreetviewExistsException)
 from geoapi.models import User, StreetviewInstance, StreetviewSequence, Task
@@ -32,8 +31,8 @@ from geoapi.db import db_session
 
 logger = logging.getLogger(__file__)
 
-def publish(user: User, params: Dict):
 
+def publish(user: User, params: Dict):
     service = params['service']
     system_id = params['system_id']
     path = params['path']
@@ -41,10 +40,8 @@ def publish(user: User, params: Dict):
 
     streetview_service = StreetviewService.getByService(user, service)
 
-    if (not streetview_service.token or not streetview_service.service_user):
-        logger.error('Not authenticated to {} for user: {}'\
-            .format(params['service'],
-                    user.username))
+    if not streetview_service.token or not streetview_service.service_user:
+        logger.error('Not authenticated to {} for user: {}'.format(params['service'], user.username))
         raise StreetviewAuthException('Not authenticated to {}!'.format(service))
 
     # TODO: Find better solution for limiting uploads.
@@ -60,30 +57,33 @@ def publish(user: User, params: Dict):
                                    path,
                                    organization_key)
 
+
 def progress_error(user: User,
-                 task_uuid: UUID,
-                 status: str=None,
-                 message: str=None,
-                 logItem: Dict=None):
-  logger.error(message)
-  message = 'Error occurred'
-  NotificationsService.create(user, status, message)
-  NotificationsService.updateProgress(task_uuid=task_uuid,
-                                      status=status,
-                                      message=message,
-                                      logItem=logItem)
+                   task_uuid: UUID,
+                   status: str = None,
+                   message: str = None,
+                   logItem: Dict = None):
+    logger.error(message)
+    message = 'Error occurred'
+    NotificationsService.create(user, status, message)
+    NotificationsService.updateProgress(task_uuid=task_uuid,
+                                        status=status,
+                                        message=message,
+                                        logItem=logItem)
+
 
 def clean_session(streetview_instance: StreetviewInstance,
                   user: User,
                   task_uuid: UUID,
-                  status: str=None,
-                  message: str=None,
-                  logItem: dict=None):
+                  status: str = None,
+                  message: str = None,
+                  logItem: dict = None):
     StreetviewService.deleteInstance(streetview_instance.id)
     progress_error(user, task_uuid, status, message, logItem)
     remove_project_streetview_dir(user.id, task_uuid)
 
-def _from_tapis(user: User, task_uuid: UUID, systemId: str, path: str, organization_key: str):
+
+def _from_tapis(user: User, task_uuid: UUID, systemId: str, path: str):
     client = AgaveUtils(user.jwt)
     listing = client.listing(systemId, path)
     files_in_directory = listing[1:]
@@ -143,8 +143,8 @@ def _to_mapillary(user: User, streetview_instance: StreetviewInstance, task_uuid
         MapillaryUtils.authenticate(user.id, token, service_user)
         MapillaryUtils.upload(user.id, task_uuid, service_user, organization_key)
     except Exception as e:
-        raise Exception("Errors during mapillary upload task {} for user {}: Error: {}" \
-                      .format(task_uuid, user.username, e))
+        raise Exception("Errors during mapillary upload task {} for user {}: Error: {}".format(task_uuid, user.username, e))
+
 
 # NOTE: At the time of writing, Mapillary's api does not return the sequence
 #       key(s) of the uploaded images. However, they do support searching
@@ -175,8 +175,8 @@ def _mapillary_finalize(user: User, streetview_instance: StreetviewInstance, tas
 def check_existing_upload(user, streetview_service, task_uuid, system_id, path):
     existing_progress = NotificationsService.getProgressUUID(task_uuid)
     existing_instance = StreetviewService.getInstanceFromSystemPath(streetview_service.id,
-                                                                   system_id,
-                                                                   path)
+                                                                    system_id,
+                                                                    path)
     # TODO: Handle existing progress
     if existing_progress or existing_instance:
         raise StreetviewExistsException("Path {f} is already in progress or uploaded."
@@ -190,7 +190,7 @@ def from_tapis_to_streetview(user_id: int,
                              system_id: str,
                              path: str,
                              organization_key: str):
-    user = UserService.get(user_id);
+    user = UserService.get(user_id)
     streetview_service = StreetviewService.get(streetview_service_id)
 
     task_uuid = uuid.uuid3(uuid.NAMESPACE_URL, system_id + path)
@@ -200,7 +200,6 @@ def from_tapis_to_streetview(user_id: int,
     except StreetviewExistsException as e:
         NotificationsService.create(user, 'warning', str(e))
         return
-
 
     # Initialize progress notification and streetview object
     NotificationsService.createProgress(user,
@@ -220,7 +219,7 @@ def from_tapis_to_streetview(user_id: int,
 
     # Get from tapis
     try:
-      _from_tapis(user, task_uuid, system_id, path, organization_key)
+        _from_tapis(user, task_uuid, system_id, path, organization_key)
     # TODO: Handle
     except Exception as e:
         error_message = "Error during getting files from tapis system:{} path:{} \
@@ -270,32 +269,32 @@ def from_tapis_to_streetview(user_id: int,
 
 
 def process_streetview_sequences(projectId, sequenceId, token) -> Task:
-        """
-        Process streetview files
+    """
+    Process streetview files
 
-        :param projectId: int
-        :param sequenceId: int
-        :param token: str
-        :return: processingTask: Task
-        """
-        streetview_sequence = db_session.query(StreetviewSequence).get(sequenceId)
+    :param projectId: int
+    :param sequenceId: int
+    :param token: str
+    :return: processingTask: Task
+    """
+    streetview_sequence = db_session.query(StreetviewSequence).get(sequenceId)
 
-        celery_task_id = celery_uuid()
-        task = Task()
-        task.process_id = celery_task_id
-        task.status = "RUNNING"
-        task.description = "Processing streetview sequence #{}".format(sequenceId)
+    celery_task_id = celery_uuid()
+    task = Task()
+    task.process_id = celery_task_id
+    task.status = "RUNNING"
+    task.description = "Processing streetview sequence #{}".format(sequenceId)
 
-        streetview_sequence.task = task
+    streetview_sequence.task = task
 
-        db_session.add(task)
-        db_session.commit()
+    db_session.add(task)
+    db_session.commit()
 
-        logger.info("Starting streetview sequence processing task for sequence (#{}).".format(sequenceId))
+    logger.info("Starting streetview sequence processing task for sequence (#{}).".format(sequenceId))
 
-        convert_streetview_sequence_to_feature.apply_async(args=[projectId, sequenceId, token], task_id=celery_task_id)
+    convert_streetview_sequence_to_feature.apply_async(args=[projectId, sequenceId, token], task_id=celery_task_id)
 
-        return task
+    return task
 
 
 class StreetviewSequenceProcessingTask(celery.Task):
@@ -381,4 +380,3 @@ def convert_streetview_sequence_to_feature(self, projectId, sequenceId, token):
     except:
         db_session.rollback()
         raise
-

--- a/geoapi/tasks/streetview.py
+++ b/geoapi/tasks/streetview.py
@@ -227,7 +227,7 @@ def from_tapis_to_streetview(user_id: int,
 
     # Get from tapis
     try:
-        _from_tapis(user, task_uuid, system_id, path, organization_key)
+        _from_tapis(user, task_uuid, system_id, path)
     # TODO: Handle
     except Exception as e:
         error_message = "Error during getting files from tapis system:{} path:{} \

--- a/geoapi/tests/tasks_tests/test_streetview.py
+++ b/geoapi/tests/tasks_tests/test_streetview.py
@@ -1,0 +1,55 @@
+from geoapi.tasks.streetview import _from_tapis
+from geoapi.utils.agave import AgaveFileListing
+from geoapi.utils.streetview import (get_project_streetview_dir, remove_project_streetview_dir)
+from unittest.mock import patch, MagicMock
+import os
+import pytest
+import uuid
+
+
+@pytest.fixture(scope="function")
+def agave_utils_with_image_file(image_file_fixture):
+    with patch('geoapi.tasks.streetview.AgaveUtils.listing') as mock_listing, \
+            patch('geoapi.tasks.streetview.AgaveUtils.get_file_context_manager') as mock_get_file_context_manager:
+        filesListing = [
+            AgaveFileListing({
+                "system": "testSystem",
+                "path": "/testPath",
+                "type": "dir",
+                "length": 4,
+                "_links": "links",
+                "mimeType": "folder",
+                "lastModified": "2020-08-31T12:00:00Z"
+            }),
+            AgaveFileListing({
+                "system": "testSystem",
+                "type": "file",
+                "length": 4096,
+                "path": "/testPath/file.jpg",
+                "_links": "links",
+                "mimeType": "image/jpeg",
+                "lastModified": "2020-08-31T12:00:00Z"
+            })
+        ]
+        mock_listing.return_value = filesListing
+        mock_file_context_manager = MagicMock()
+        mock_get_file_context_manager.return_value = mock_file_context_manager
+        mock_file_context_manager.__enter__.return_value = image_file_fixture
+        yield
+
+
+@pytest.fixture
+def mock_notifications_service():
+    with patch('geoapi.tasks.streetview.NotificationsService') as MockNotificationsService:
+        yield MockNotificationsService()
+
+
+def test_get_file_to_path(user1, task_fixture, mock_notifications_service, agave_utils_with_image_file):
+    system_id = "foo"
+    path = "path/"
+    task_uuid = uuid.uuid3(uuid.NAMESPACE_URL, system_id + path)
+
+    _from_tapis(user1, task_uuid, system_id, path)
+
+    assert len(os.listdir(get_project_streetview_dir(user1.id, task_uuid))) == 1
+    remove_project_streetview_dir(user1.id, task_uuid)

--- a/geoapi/tests/utils_tests/test_agave.py
+++ b/geoapi/tests/utils_tests/test_agave.py
@@ -1,4 +1,6 @@
 import pytest
+import os
+import tempfile
 from unittest.mock import patch, call
 from geoapi.exceptions import MissingServiceAccount
 from geoapi.utils.agave import service_account_client, AgaveUtils, AgaveFileGetError
@@ -31,6 +33,21 @@ def test_get_file(requests_mock, retry_sleep_seconds_mock, image_file_fixture):
                       body=image_file_fixture)
     agave_utils = AgaveUtils()
     agave_utils.getFile(system, path)
+
+
+def test_get_file_to_path(requests_mock, projects_fixture, retry_sleep_seconds_mock, image_file_fixture):
+    system = "system"
+    path = "path"
+    requests_mock.get(AgaveUtils.BASE_URL + f"/files/media/system/{system}/{path}",
+                      status_code=200,
+                      body=image_file_fixture)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        to_path = os.path.join(temp_dir, "test.jpg")
+
+        agave_utils = AgaveUtils()
+        agave_utils.get_file_to_path(system, path, to_path)
+        assert os.path.isfile(to_path)
 
 
 def test_get_file_retry_after_first_attempt(requests_mock, retry_sleep_seconds_mock, image_file_fixture):

--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -228,11 +228,9 @@ class AgaveUtils:
         logger.exception(msg)
         raise AgaveFileGetError(msg)
 
-
     def get_file_context_manager(self, system_id: str, path: str) -> IO:
         tmpFile = self.getFile(system_id, path)
         return closing(tmpFile)
-
 
     def get_file_to_path(self, system_id: str, path: str, destination_path: str):
         """

--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -16,6 +16,7 @@ from geoapi.settings import settings
 from geoapi.utils.tenants import get_api_server, get_service_accounts
 from geoapi.exceptions import MissingServiceAccount
 from geoapi.custom import custom_system_user_retrieval
+from contextlib import closing
 
 logger = logging.getLogger(__name__)
 
@@ -201,6 +202,8 @@ class AgaveUtils:
         where tapis hits an ssh limits and then we get a a 500 or a file with 0 bytes). Eventually
         we will raise AgaveFileGetError if we can't get the file.
 
+        User needs to ensure they call `close()` on the returned temp file
+
         :raises
             AgaveFileGetError: Raised if unable to get file via tapis.
 
@@ -225,18 +228,27 @@ class AgaveUtils:
         logger.exception(msg)
         raise AgaveFileGetError(msg)
 
-    def getRawFileToPath(self, systemId: str, fromPath: str, toPath: str):
-        url = quote('/files/media/system/{}/{}'.format(systemId, fromPath))
-        try:
-            with self.client.get(self.base_url + url, stream=True) as r:
-                if r.status_code > 400:
-                    raise ValueError("Could not fetch file: {}".format(r.status_code))
-                with open(toPath, 'wb') as out_file:
-                    r.raw.decode_content = True
-                    shutil.copyfileobj(r.raw, out_file)
-        except Exception as e:
-            logger.error(e)
-            raise e
+
+    def get_file_context_manager(self, system_id: str, path: str) -> IO:
+        tmpFile = self.getFile(system_id, path)
+        return closing(tmpFile)
+
+
+    def get_file_to_path(self, system_id: str, path: str, destination_path: str):
+        """
+          Download a file from tapis
+
+          This method differs from getFile as here we write to non-temporary file
+
+          :param system_id: str
+          :param path: str
+          :param destination_path: str desired location of file
+
+          :return: temporary file
+        """
+        with self.get_file_context_manager(system_id, path) as file_obj:
+            with open(destination_path, 'wb+') as target_file:
+                shutil.copyfileobj(file_obj, target_file)
 
 
 def service_account_client(tenant_id):

--- a/geoapi/utils/streetview.py
+++ b/geoapi/utils/streetview.py
@@ -5,7 +5,7 @@ import re
 import json
 import subprocess
 import datetime
-from typing import Dict, List
+from typing import List
 from uuid import UUID
 
 from geoapi.services.notifications import NotificationsService
@@ -88,7 +88,7 @@ class MapillaryUtils:
             return
 
         command = [
-            'mapillary_tools',
+            '/opt/conda/bin/mapillary_tools',
             'authenticate',
             '--user_name',
             service_user,
@@ -104,7 +104,7 @@ class MapillaryUtils:
                                'MAPILLARY_CONFIG_PATH': MapillaryUtils.get_auth_file(userId)
                            })
         except subprocess.CalledProcessError as e:
-            error_message = "Errors occured during Mapillary authentication for user with userId: {}. {}"\
+            error_message = "Errors occurred during Mapillary authentication for user with userId: {}. {}"\
                 .format(userId, e)
             raise ApiException(error_message)
 
@@ -115,7 +115,7 @@ class MapillaryUtils:
     @staticmethod
     def upload(userId: int, task_uuid: UUID, service_user: str, organization_key: str):
         command = [
-            'mapillary_tools',
+            '/opt/conda/bin/mapillary_tools',
             'process_and_upload',
             get_project_streetview_dir(userId, task_uuid),
             '--user_name',
@@ -153,7 +153,7 @@ class MapillaryUtils:
                                                         "Processing upload...")
 
         except Exception as e:
-            error_message = "Error occured mapillary_tools upload task for user with id: {} \n {}"\
+            error_message = "Error occurred mapillary_tools upload task for user with id: {} \n {}"\
                           .format(userId, str(e))
             logger.error(error_message)
             raise Exception(error_message)

--- a/geoapi/utils/streetview.py
+++ b/geoapi/utils/streetview.py
@@ -88,7 +88,7 @@ class MapillaryUtils:
             return
 
         command = [
-            '/usr/local/bin/mapillary_tools',
+            'mapillary_tools',
             'authenticate',
             '--user_name',
             service_user,

--- a/geoapi/utils/streetview.py
+++ b/geoapi/utils/streetview.py
@@ -115,7 +115,7 @@ class MapillaryUtils:
     @staticmethod
     def upload(userId: int, task_uuid: UUID, service_user: str, organization_key: str):
         command = [
-            '/usr/local/bin/mapillary_tools',
+            'mapillary_tools',
             'process_and_upload',
             get_project_streetview_dir(userId, task_uuid),
             '--user_name',


### PR DESCRIPTION
## Overview: ##

This PR fixes two issues that are affecting the use of importing files to mapillary:
* [WG-66](https://jira.tacc.utexas.edu/browse/WG-66). Fixes the path to mapillary tools
* [WG-36](https://jira.tacc.utexas.edu/browse/WG-36). Use a consistent way to get files from tapis systems. The standalone `getRawFileToPath`(previously used by streetview) is replaced with the `getFile` method which is used in other places and (especially since https://github.com/TACC-Cloud/geoapi/pull/99) provides a fault-tolerant approach for retrieving files
* some linting changes to `geoapi/tasks/streetview.py`

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-36: Review getRawFileToPath after DES-2236 work-around](https://jira.tacc.utexas.edu/browse/WG-36)
* [WG-66: Fix path of mapillary_tools](https://jira.tacc.utexas.edu/browse/WG-66)	

## Testing Steps: ##
1.  Deployed to staging (best to test there)
2. Create a new map
3. Log into mapillary using the streetview button on the left panel (ensure your username and organization is set up)
4. Then lick on publish button
5. Select a folder containing streetview images (`100_images_subset` folder in project _PRJ-3967 | Streetview Test (small subset of a seattle survey from UW/RAPID)_)
