### PR TITLE
Update script to ensure pods are RUNNING

### DIFF
--- a/kube/utils/backup_staging_production_to_ranch.sh
+++ b/kube/utils/backup_staging_production_to_ranch.sh
@@ -1,8 +1,30 @@
 #!/bin/bash
 set -ex
 
+#starting production-assets-util
 kubectl --context=wma-geospatial apply -f ~geoapi/util/production_assets_util.yaml
+#starting staging-assets-util
 kubectl --context=geoapi-dev apply -f ~geoapi/util/staging_assets_util.yaml
+
+# Function to check if both pods are in the "Running" state
+function are_pods_running() {
+    local pod1_status=$(kubectl --context=wma-geospatial get pods production-assets-util  -o jsonpath='{.status.phase}')
+    local pod2_status=$(kubectl --context=geoapi-dev get pods staging-assets-util -o jsonpath='{.status.phase}')
+
+    if [[ "$pod1_status" == "Running" ]] && [[ "$pod2_status" == "Running" ]]; then
+        return 0  # Both pods are running
+    else
+        return 1  # At least one pod is not running
+    fi
+}
+
+# Wait for both pods to be ready
+while ! are_pods_running; do
+    echo "Waiting 30s for utility pods to be ready..."
+    sleep 30
+done
+
+echo "Both utility pods are ready."
 
 echo "Removing backups older than 6 weeks (i.e. 42 days) (STAGING)"
 ssh tg458981@ranch.tacc.utexas.edu 'find /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/staging/ -mtime +42 -type f -exec rm {} +'


### PR DESCRIPTION
## Overview: ##

Update the backup script to ensure pods are running before the backup/ssh begins. Discussions in thread [here](https://tacc-team.slack.com/archives/C04TMKBDS1X/p1693113790448049):

Fixes issue seen in failed [jenkins job ](https://tacc-team.slack.com/archives/C04TMKBDS1X/p1693113790448049).

Running in currently in this [jenkins job](https://jenkins01.tacc.utexas.edu/job/Geoapi%20(assets%20backup)/376/).

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

N/A