### PR TITLE
hotfix: remove vestigial geoapi-postgres from kube workflow

### DIFF
--- a/kube/Makefile
+++ b/kube/Makefile
@@ -32,8 +32,8 @@ create: checkforcontext checkfortag
 .PHONY: delete
 delete: checkforcontext
 	@echo "Deleting geoapi deployment/services/migration-job in '$(KUBE_CONTEXT)' context"
-	kubectl delete --context $(KUBE_CONTEXT) --ignore-not-found=true  deployment geoapi geoapi-workers geoapi-celerybeat geoapi-nginx geoapi-postgres geoapi-rabbitmq
-	kubectl delete --context $(KUBE_CONTEXT) --ignore-not-found=true service geoapi geoapi-nginx geoapi-postgres geoapi-rabbitmq
+	kubectl delete --context $(KUBE_CONTEXT) --ignore-not-found=true  deployment geoapi geoapi-workers geoapi-celerybeat geoapi-nginx geoapi-rabbitmq
+	kubectl delete --context $(KUBE_CONTEXT) --ignore-not-found=true service geoapi geoapi-nginx geoapi-rabbitmq
 	kubectl delete --context $(KUBE_CONTEXT) --ignore-not-found=true job/geoapi-migrations
 
 .PHONY: delete-staging

--- a/kube/geoapi.yaml
+++ b/kube/geoapi.yaml
@@ -95,22 +95,6 @@ metadata:
     kompose.cmd: kompose convert
     kompose.version: 1.16.0 (0c01309)
   labels:
-    app: geoapi-postgres
-  name: geoapi-postgres
-spec:
-  ports:
-  - port: 5432
-    targetPort: 5432
-  selector:
-    app: geoapi-postgres
----
-apiVersion: v1
-kind: Service
-metadata:
-  annotations:
-    kompose.cmd: kompose convert
-    kompose.version: 1.16.0 (0c01309)
-  labels:
     app: geoapi-nginx
   name: geoapi-nginx
 spec:


### PR DESCRIPTION
## Overview: ##

The PR removes vestigial geoapi-postgres from kube workflow now that we have dedicated database vm.

## PR Status: ##

* [X] Ready.

