### PR TITLE
task/WG-141: Fix db connections for celery workers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,6 @@ services:
       - APP_ENV=development
       - ASSETS_BASE_DIR=/assets
       - TENANT
-      - APP_CONTEXT=celery
     stdin_open: true
     tty: true
     container_name: geoapiworkers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       - APP_ENV=development
       - ASSETS_BASE_DIR=/assets
       - TENANT
+      - APP_CONTEXT=celery
     stdin_open: true
     tty: true
     container_name: geoapiworkers

--- a/geoapi/app.py
+++ b/geoapi/app.py
@@ -62,6 +62,7 @@ def handle_streetview_auth_exception(error: Exception):
 def handle_streetview_limit_exception(error: Exception):
     return {'message': 'Exceed concurrent streetview publish limit'}, 403
 
+
 # ensure SQLAlchemy sessions are properly closed at the end of each request.
 @app.teardown_appcontext
 def shutdown_session(exception=None):

--- a/geoapi/app.py
+++ b/geoapi/app.py
@@ -62,7 +62,7 @@ def handle_streetview_auth_exception(error: Exception):
 def handle_streetview_limit_exception(error: Exception):
     return {'message': 'Exceed concurrent streetview publish limit'}, 403
 
-
+# ensure SQLAlchemy sessions are properly closed at the end of each request.
 @app.teardown_appcontext
 def shutdown_session(exception=None):
     db_session.remove()

--- a/geoapi/celery_app.py
+++ b/geoapi/celery_app.py
@@ -21,7 +21,3 @@ app.conf.beat_schedule = {
     }
 }
 
-
-@app.task
-def hello():
-    return "Hello World"

--- a/geoapi/celery_app.py
+++ b/geoapi/celery_app.py
@@ -20,4 +20,3 @@ app.conf.beat_schedule = {
         'schedule': crontab(hour='*', minute='0')
     }
 }
-

--- a/geoapi/db.py
+++ b/geoapi/db.py
@@ -9,7 +9,10 @@ CONNECTION_STRING = 'postgresql://{}:{}@{}/{}'.format(
     settings.DB_HOST,
     settings.DB_NAME
 )
-engine = create_engine(CONNECTION_STRING, echo=False)
+engine = create_engine(CONNECTION_STRING,
+                       echo=False,  # default value
+                       pool_pre_ping=True,
+                       pool_reset_on_return=True)
 
 db_session = scoped_session(sessionmaker(autocommit=False,
                                          autoflush=False,

--- a/geoapi/db.py
+++ b/geoapi/db.py
@@ -3,7 +3,9 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.pool import NullPool
 from geoapi.settings import settings
+from contextlib import contextmanager
 import os
+from geoapi.log import logger
 
 
 CONNECTION_STRING = 'postgresql://{}:{}@{}/{}'.format(
@@ -14,8 +16,9 @@ CONNECTION_STRING = 'postgresql://{}:{}@{}/{}'.format(
 )
 
 
-def create_engine_for_context():
+def create_engine_for_context(context=None):
     context = os.environ.get('APP_CONTEXT', 'flask')  # Default to 'flask' if not provided
+    logger.debug(f"Creating database engine for {context} context.")
     if context == "celery":
         # celery to disable pool (i.e. NullPool) due to https://jira.tacc.utexas.edu/browse/WG-141 and
         # https://jira.tacc.utexas.edu/browse/WG-131
@@ -32,8 +35,27 @@ def create_engine_for_context():
 
 engine = create_engine_for_context()
 
+# thread-local db session (which is used by flask requests)
 db_session = scoped_session(sessionmaker(autocommit=False,
                                          autoflush=False,
                                          bind=engine))
 
 Base = declarative_base()
+
+
+@contextmanager
+def create_task_session():
+    """Create session
+
+    Session is used by celery tasks: it ensures they are removed and handles rollback in case of exceptions
+    """
+    Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = Session()
+    try:
+        yield session
+    except:
+        logger.exception("Error occurred. Performing rollback of current database transaction")
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/geoapi/db.py
+++ b/geoapi/db.py
@@ -1,7 +1,10 @@
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.pool import NullPool
 from geoapi.settings import settings
+import os
+
 
 CONNECTION_STRING = 'postgresql://{}:{}@{}/{}'.format(
     settings.DB_USERNAME,
@@ -9,10 +12,23 @@ CONNECTION_STRING = 'postgresql://{}:{}@{}/{}'.format(
     settings.DB_HOST,
     settings.DB_NAME
 )
-engine = create_engine(CONNECTION_STRING,
-                       echo=False,  # default value
-                       pool_pre_ping=True,
-                       pool_reset_on_return=True)
+
+def create_engine_for_context():
+    context = os.environ.get('APP_CONTEXT', 'flask')  # Default to 'flask' if not provided
+    if context == "celery":
+        # celery to disable pool (i.e. NullPool) due to https://jira.tacc.utexas.edu/browse/WG-141 and
+        # https://jira.tacc.utexas.edu/browse/WG-131
+        engine = create_engine(CONNECTION_STRING,
+                               echo=False,  # default value
+                               poolclass=NullPool)
+    else:
+        engine = create_engine(CONNECTION_STRING,
+                               echo=False,  # default value
+                               pool_pre_ping=True,
+                               pool_reset_on_return=True)
+    return engine
+
+engine = create_engine_for_context()
 
 db_session = scoped_session(sessionmaker(autocommit=False,
                                          autoflush=False,

--- a/geoapi/db.py
+++ b/geoapi/db.py
@@ -13,6 +13,7 @@ CONNECTION_STRING = 'postgresql://{}:{}@{}/{}'.format(
     settings.DB_NAME
 )
 
+
 def create_engine_for_context():
     context = os.environ.get('APP_CONTEXT', 'flask')  # Default to 'flask' if not provided
     if context == "celery":
@@ -27,6 +28,7 @@ def create_engine_for_context():
                                pool_pre_ping=True,
                                pool_reset_on_return=True)
     return engine
+
 
 engine = create_engine_for_context()
 

--- a/geoapi/routes/notifications.py
+++ b/geoapi/routes/notifications.py
@@ -1,6 +1,7 @@
 from flask import request
 from flask_restx import Resource, Namespace, fields
 
+from geoapi.db import db_session
 from geoapi.log import logging
 from geoapi.utils.decorators import jwt_decoder, not_anonymous
 from geoapi.services.notifications import NotificationsService
@@ -53,7 +54,7 @@ class Notifications(Resource):
     def get(self):
         query = self.parser.parse_args()
         u = request.current_user
-        return NotificationsService.get(u, query)
+        return NotificationsService.get(db_session, u, query)
 
 
 @api.route("/progress")
@@ -63,13 +64,13 @@ class ProgressNotifications(Resource):
     @api.marshal_with(progress_notification_response, as_list=True)
     def get(self):
         u = request.current_user
-        return NotificationsService.getProgress(u)
+        return NotificationsService.getProgress(db_session, u)
 
     @api.doc(id="delete",
              description='Delete all done progress notifications')
     @api.marshal_with(progress_notification_response, as_list=True)
     def delete(self):
-        return NotificationsService.deleteAllDoneProgress()
+        return NotificationsService.deleteAllDoneProgress(db_session)
 
 
 @api.route("/progress/<string:progressUUID>")
@@ -78,10 +79,10 @@ class ProgressNotificationResource(Resource):
              description='Get a specific progress notification')
     @api.marshal_with(progress_notification_response)
     def get(self, progressUUID):
-        return NotificationsService.getProgressUUID(progressUUID)
+        return NotificationsService.getProgressUUID(db_session, progressUUID)
 
     @api.doc(id="delete",
              description='Delete a specific progress notification')
     @api.marshal_with(ok_response)
     def delete(self, progressUUID):
-        return NotificationsService.deleteProgress(progressUUID)
+        return NotificationsService.deleteProgress(db_session, progressUUID)

--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -550,25 +550,7 @@ class ProjectPointCloudResource(Resource):
     def get(self, projectId: int, pointCloudId: int):
         return PointCloudService.get(db_session, pointCloudId)
 
-    @api.doc(id="uploadPointCloud",
-             description='Add a file to a point cloud. Current allowed file types are las and laz.')
-    @api.expect(file_upload_parser)
-    @api.marshal_with(task)
-    @project_permissions
-    @project_point_cloud_exists
-    @project_point_cloud_not_processing
-    def post(self, projectId: int, pointCloudId: int):
-        """
-        :raises InvalidCoordinateReferenceSystem: in case  file missing coordinate reference system
-        """
-        f = request.files['file']
-        file_name = secure_filename(f.filename)
-        logger.info("Add a file to a point cloud:{} in project:{} for user:{}: {}".format(
-            pointCloudId, projectId, request.current_user.username, file_name))
-        pc_task = PointCloudService.fromFileObj(pointCloudId, f, file_name)
-        return pc_task
-
-    @api.doc(id="updatePointCLoud",
+    @api.doc(id="updatePointCloud",
              description="Update point cloud")
     @api.marshal_with(point_cloud)
     @api.expect(point_cloud)

--- a/geoapi/routes/streetview.py
+++ b/geoapi/routes/streetview.py
@@ -2,6 +2,7 @@ from geoapi.services.streetview import StreetviewService
 from geoapi.tasks import streetview
 from geoapi.log import logging
 from geoapi.utils.decorators import jwt_decoder
+from geoapi.db import db_session
 from flask_restx import Namespace, Resource, fields
 from flask_restx.marshalling import marshal_with
 from flask import request
@@ -77,7 +78,7 @@ class StreetviewServiceResources(Resource):
     def get(self):
         u = request.current_user
         logger.info("Get all streetview objects user:{}".format(u.username))
-        return StreetviewService.list(u)
+        return StreetviewService.list(db_session, u)
 
     @api.doc(id="createStreetviewServiceResource",
              description="Create streetview service object for a user")
@@ -87,7 +88,7 @@ class StreetviewServiceResources(Resource):
         u = request.current_user
         service = api.payload.get('service')
         logger.info("Create streetview object for user:{} and service:{}".format(u.username, service))
-        return StreetviewService.create(u, api.payload)
+        return StreetviewService.create(db_session, u, api.payload)
 
 
 @api.route('/services/<service>/')
@@ -98,14 +99,14 @@ class StreetviewServiceResource(Resource):
     def get(self, service: str):
         u = request.current_user
         logger.info("Get streetview service object for service:{} for user:{}".format(service, u.username))
-        return StreetviewService.getByService(u, service)
+        return StreetviewService.getByService(db_session, u, service)
 
     @api.doc(id="deleteStreetviewServiceResource",
              description="Delete a streetview service resource by service name")
     def delete(self, service: str):
         u = request.current_user
         logger.info("Delete streetview object for service:{} for user:{}".format(service, u.username))
-        return StreetviewService.deleteByService(u, service)
+        return StreetviewService.deleteByService(db_session, u, service)
 
     @api.doc(id="updateStreetviewServiceResource",
              description="Update streetview service resource for a user by service name")
@@ -114,7 +115,7 @@ class StreetviewServiceResource(Resource):
     def put(self, service: str):
         u = request.current_user
         logger.info("Update streetview service resource for service:{} user:{}".format(service, u.username))
-        return StreetviewService.updateByService(u, service, api.payload)
+        return StreetviewService.updateByService(db_session, u, service, api.payload)
 
 
 @api.route('/services/<service>/organization/')
@@ -126,7 +127,7 @@ class StreetviewOrganizationsResource(Resource):
         u = request.current_user
         logger.info("Get streetview organizations from streetview service resource for user:{}"
                     .format(u.username))
-        return StreetviewService.getAllOrganizations(u, service)
+        return StreetviewService.getAllOrganizations(db_session, u, service)
 
     @api.doc(id="createStreetviewOrganizations",
              description="Create organizations for a streetview object")
@@ -136,7 +137,7 @@ class StreetviewOrganizationsResource(Resource):
         u = request.current_user
         logger.info("Create streetview organization for a streetview service resource for user:{}"
                     .format(u.username))
-        return StreetviewService.createOrganization(u, service, api.payload)
+        return StreetviewService.createOrganization(db_session, u, service, api.payload)
 
 
 @api.route('/services/<service>/organization/<organization_id>/')
@@ -147,7 +148,7 @@ class StreetviewOrganizationResource(Resource):
         u = request.current_user
         logger.info("Delete streetview organization from streetview service resource for user:{} and streetview service: {}"
                     .format(u.username, service))
-        StreetviewService.deleteOrganization(organization_id)
+        StreetviewService.deleteOrganization(db_session, organization_id)
 
     @api.doc(id="updateStreetviewOrganization",
              description="Update organization from streetview service resource")
@@ -156,7 +157,7 @@ class StreetviewOrganizationResource(Resource):
         u = request.current_user
         logger.info("Update streetview organization in streetview service resource for user:{} and streetview servicde: {}"
                     .format(u.username, service))
-        return StreetviewService.updateOrganization(organization_id, api.payload)
+        return StreetviewService.updateOrganization(db_session, organization_id, api.payload)
 
 
 @api.route('/instances/<instance_id>/')
@@ -167,7 +168,7 @@ class StreetviewInstanceResource(Resource):
         u = request.current_user
         logger.info("Delete streetview instance for user:{}"
                     .format(u.username))
-        StreetviewService.deleteInstance(instance_id)
+        StreetviewService.deleteInstance(db_session, instance_id)
 
 
 @api.route('/sequences/')
@@ -179,7 +180,7 @@ class StreetviewSequencesResource(Resource):
         payload = request.json
         logger.info("Add streetview sequence to streetview instance for user:{}"
                     .format(u.username))
-        StreetviewService.addSequenceToInstance(u, payload)
+        StreetviewService.addSequenceToInstance(db_session, u, payload)
 
 
 @api.route('/sequences/<sequence_id>/')
@@ -190,14 +191,14 @@ class StreetviewSequenceResource(Resource):
     def get(self, sequence_id: str):
         u = request.current_user
         logger.info("Get streetview sequence of id:{} for user:{}".format(sequence_id, u.username))
-        return StreetviewService.getSequenceFromId(sequence_id)
+        return StreetviewService.getSequenceFromId(db_session, sequence_id)
 
     @api.doc(id="deleteStreetviewSequence",
              description="Delete a streetview service's sequence")
     def delete(self, sequence_id: int):
         u = request.current_user
         logger.info("Delete streetview sequence of id:{} for user:{}".format(sequence_id, u.username))
-        StreetviewService.deleteSequence(sequence_id)
+        StreetviewService.deleteSequence(db_session, sequence_id)
 
     @api.doc(id="updateStreetviewSequence",
              description="Update a streetview service's sequence")
@@ -206,7 +207,7 @@ class StreetviewSequenceResource(Resource):
     def put(self, sequence_id: int):
         u = request.current_user
         logger.info("Update streetview sequence of id:{} for user:{}".format(sequence_id, u.username))
-        return StreetviewService.updateSequence(sequence_id, api.payload)
+        return StreetviewService.updateSequence(db_session, db_session, sequence_id, api.payload)
 
 
 @api.route('/publish/')
@@ -221,5 +222,5 @@ class StreetviewPublishFilesResource(Resource):
     def post(self):
         u = request.current_user
         logger.info("Publish images to streetview for user:{}".format(u.username))
-        streetview.publish(u, api.payload)
+        streetview.publish(db_session, u, api.payload)
         return {"message": "accepted"}

--- a/geoapi/services/imports.py
+++ b/geoapi/services/imports.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from geoapi.db import db_session
 from geoapi.models import ImportedFile
 from geoapi.log import logging
 
@@ -10,8 +9,8 @@ logger = logging.getLogger(__name__)
 class ImportsService():
 
     @staticmethod
-    def getImport(projectId: int, systemId: str, path: str) -> ImportedFile:
-        return db_session.query(ImportedFile)\
+    def getImport(database_session, projectId: int, systemId: str, path: str) -> ImportedFile:
+        return database_session.query(ImportedFile)\
             .filter(ImportedFile.project_id == projectId) \
             .filter(ImportedFile.system_id == systemId) \
             .filter(ImportedFile.path == path)\

--- a/geoapi/services/notifications.py
+++ b/geoapi/services/notifications.py
@@ -3,7 +3,6 @@ from typing import List, AnyStr, Dict
 from geoapi.models import Notification, ProgressNotification
 from geoapi.models import User
 from uuid import UUID
-from geoapi.db import db_session
 from geoapi.log import logging
 
 logger = logging.getLogger(__file__)
@@ -12,8 +11,8 @@ logger = logging.getLogger(__file__)
 class NotificationsService:
 
     @staticmethod
-    def getAll(user: User) -> List[Notification]:
-        return db_session.query(Notification) \
+    def getAll(database_session, user: User) -> List[Notification]:
+        return database_session.query(Notification) \
             .filter(Notification.username == user.username) \
             .filter(Notification.tenant_id == user.tenant_id) \
             .order_by(Notification.created.desc()) \
@@ -21,8 +20,8 @@ class NotificationsService:
             .all()
 
     @staticmethod
-    def get(user: User, filters: Dict) -> List[Notification]:
-        q = db_session.query(Notification) \
+    def get(database_session, user: User, filters: Dict) -> List[Notification]:
+        q = database_session.query(Notification) \
             .filter(Notification.username == user.username) \
             .filter(Notification.tenant_id == user.tenant_id)
         if filters.get("startDate"):
@@ -31,7 +30,7 @@ class NotificationsService:
             .limit(100).all()
 
     @staticmethod
-    def create(user: User, status: AnyStr, message: AnyStr) -> Notification:
+    def create(database_session, user: User, status: AnyStr, message: AnyStr) -> Notification:
         note = Notification(
             username=user.username,
             tenant_id=user.tenant_id,
@@ -39,35 +38,35 @@ class NotificationsService:
             message=message
         )
         try:
-            db_session.add(note)
-            db_session.commit()
+            database_session.add(note)
+            database_session.commit()
             return note
         except Exception:
-            db_session.rollback()
+            database_session.rollback()
             raise
 
     @staticmethod
-    def getProgress(user: User) -> List[ProgressNotification]:
-        q = db_session.query(ProgressNotification) \
+    def getProgress(database_session, user: User) -> List[ProgressNotification]:
+        q = database_session.query(ProgressNotification) \
             .filter(ProgressNotification.user_id == user.id) \
             .filter(ProgressNotification.tenant_id == user.tenant_id)
         return q.order_by(ProgressNotification.created.desc()) \
             .limit(100).all()
 
     @staticmethod
-    def getProgressUUID(task_uuid: UUID) -> ProgressNotification:
-        return db_session.query(ProgressNotification) \
+    def getProgressUUID(database_session, task_uuid: UUID) -> ProgressNotification:
+        return database_session.query(ProgressNotification) \
             .filter(ProgressNotification.uuid == task_uuid) \
             .first()
 
     @staticmethod
-    def getProgressStatus(status: str) -> List[ProgressNotification]:
-        return db_session.query(ProgressNotification) \
+    def getProgressStatus(database_session, status: str) -> List[ProgressNotification]:
+        return database_session.query(ProgressNotification) \
             .filter(ProgressNotification.status == status) \
             .all()
 
     @staticmethod
-    def createProgress(user: User, status: AnyStr, message: AnyStr, task_uuid: UUID,
+    def createProgress(database_session, user: User, status: AnyStr, message: AnyStr, task_uuid: UUID,
                        logs: List = None) -> ProgressNotification:
         note = ProgressNotification(
             user_id=user.id,
@@ -78,56 +77,40 @@ class NotificationsService:
             message=message,
             logs=logs
         )
-        try:
-            db_session.add(note)
-            db_session.commit()
-            return note
-        except Exception:
-            db_session.rollback()
-            raise
+        database_session.add(note)
+        database_session.commit()
+        return note
 
     @staticmethod
-    def updateProgress(task_uuid: UUID, status: AnyStr = None, message: AnyStr = None, progress: int = None,
+    def updateProgress(database_session, task_uuid: UUID, status: AnyStr = None, message: AnyStr = None, progress: int = None,
                        logItem: Dict = None):
-        note = db_session.query(ProgressNotification) \
+        note = database_session.query(ProgressNotification) \
             .filter(ProgressNotification.uuid == task_uuid) \
             .first()
-        try:
-            if status is not None:
-                note.status = status
-            if message is not None:
-                note.message = message
-            if progress is not None:
-                note.progress = progress
-            if logItem is not None:
-                new_log = note.logs
-                new_log.update(logItem)
-                note.extraData = new_log
-            db_session.commit()
-        except Exception:
-            db_session.rollback()
-            raise
+        if status is not None:
+            note.status = status
+        if message is not None:
+            note.message = message
+        if progress is not None:
+            note.progress = progress
+        if logItem is not None:
+            new_log = note.logs
+            new_log.update(logItem)
+            note.extraData = new_log
+        database_session.commit()
 
     @staticmethod
-    def deleteProgress(task_uuid: UUID):
-        notes = db_session.query(ProgressNotification) \
+    def deleteProgress(database_session, task_uuid: UUID):
+        notes = database_session.query(ProgressNotification) \
             .filter(ProgressNotification.uuid == task_uuid)
-        try:
-            for i in notes:
-                db_session.delete(i)
-            db_session.commit()
-        except Exception:
-            db_session.rollback()
-            raise
+        for i in notes:
+            database_session.delete(i)
+        database_session.commit()
 
     @staticmethod
-    def deleteAllDoneProgress():
-        note = db_session.query(ProgressNotification) \
+    def deleteAllDoneProgress(database_session):
+        note = database_session.query(ProgressNotification) \
             .filter(ProgressNotification.status == 'success')
-        try:
-            for pn in note:
-                db_session.delete(pn)
-            db_session.commit()
-        except Exception:
-            db_session.rollback()
-            raise
+        for pn in note:
+            database_session.delete(pn)
+        database_session.commit()

--- a/geoapi/services/point_cloud.py
+++ b/geoapi/services/point_cloud.py
@@ -132,43 +132,6 @@ class PointCloudService:
         return file_path
 
     @staticmethod
-    def fromFileObj(pointCloudId: int, fileObj: IO, fileName: str):
-        """
-        Add a point cloud file
-
-        When point cloud file has been processed, a feature will be created/updated with feature
-        asset containing processed point cloud
-
-        Different processing steps are applied asynchronously by default.
-
-        :param pointCloudId: int
-        :param fileObj: IO
-        :param fileName: str
-        :return: processingTask: Task
-        """
-        PointCloudService.check_file_extension(fileName)
-
-        point_cloud = PointCloudService.get(pointCloudId)
-
-        file_path = PointCloudService.putPointCloudInOriginalsFileDir(point_cloud.path, fileObj, fileName)
-
-        try:
-            result = check_point_cloud.apply_async(args=[file_path])
-            result.get()
-        except InvalidCoordinateReferenceSystem as e:
-            os.remove(file_path)
-            logger.error("Point cloud file ({}) missing required coordinate reference system".format(file_path))
-            raise e
-
-        result = get_point_cloud_info.apply_async(args=[pointCloudId])
-        point_cloud.files_info = json.dumps(result.get())
-
-        db_session.add(point_cloud)
-        db_session.commit()
-
-        return PointCloudService._process_point_clouds(pointCloudId)
-
-    @staticmethod
     def _process_point_clouds(database_session, pointCloudId: int) -> Task:
         """
         Process point cloud files

--- a/geoapi/services/streetview.py
+++ b/geoapi/services/streetview.py
@@ -4,7 +4,6 @@ from datetime import datetime
 import uuid
 
 from geoapi.models import User, Streetview, StreetviewInstance, StreetviewSequence, StreetviewOrganization, Project, Task
-from geoapi.db import db_session
 from geoapi.log import logging
 
 
@@ -13,13 +12,13 @@ logger = logging.getLogger(__name__)
 
 class StreetviewService:
     @staticmethod
-    def list(user: User) -> List[Streetview]:
+    def list(database_session, user: User) -> List[Streetview]:
         """
         Get all streetview objects for a user
         :param user: User
         :return: List[Streetview]
         """
-        streetviews = db_session.query(Streetview) \
+        streetviews = database_session.query(Streetview) \
             .join(User.streetviews) \
             .filter(User.username == user.username) \
             .filter(User.tenant_id == user.tenant_id) \
@@ -29,33 +28,33 @@ class StreetviewService:
 
 
     @staticmethod
-    def update(id: int, data: Dict) -> Streetview:
+    def update(database_session, id: int, data: Dict) -> Streetview:
         """
         Update a Streetview object for a user.
         :param id: int
         :param data: Dict
         :return: Streetview
         """
-        sv = StreetviewService.get(id)
+        sv = StreetviewService.get(database_session, id)
 
         for key, value in data.items():
             setattr(sv, key, value)
 
-        db_session.commit()
+        database_session.commit()
 
         return sv
 
 
     @staticmethod
-    def create(user: User, data: Dict) -> Streetview:
+    def create(database_session, user: User, data: Dict) -> Streetview:
         """
         Create a Streetview object for a user to contain service information.
         :param user: User
         :param data: Dict
         :return: Streetview
         """
-        if StreetviewService.getByService(user, data['service']):
-            StreetviewService.deleteByService(user, data['service'])
+        if StreetviewService.getByService(database_session, user, data['service']):
+            StreetviewService.deleteByService(database_session, user, data['service'])
 
         sv = Streetview()
         sv.user_id = user.id
@@ -63,35 +62,35 @@ class StreetviewService:
         for key, value in data.items():
             setattr(sv, key, value)
 
-        db_session.add(sv)
-        db_session.commit()
+        database_session.add(sv)
+        database_session.commit()
 
         return sv
 
     @staticmethod
-    def get(streetview_id: int) -> Streetview:
+    def get(database_session, streetview_id: int) -> Streetview:
         """
         Retreive a single Streetview Service
         :param streetview_id: int
         :return: Streetview
         """
-        return db_session.query(Streetview).get(streetview_id)
+        return database_session.query(Streetview).get(streetview_id)
 
     @staticmethod
-    def getByService(user: User, service: str) -> Streetview:
+    def getByService(database_session, user: User, service: str) -> Streetview:
         """
         Retreive a single Streetview Service by service name
         :param user: User
         :param service: str
         :return: Streetview
         """
-        return db_session.query(Streetview)\
+        return database_session.query(Streetview)\
             .filter(Streetview.user_id == user.id)\
             .filter(Streetview.service == service)\
             .first()
 
     @staticmethod
-    def updateByService(user: User, service: str, data: Dict) -> Streetview:
+    def updateByService(database_session, user: User, service: str, data: Dict) -> Streetview:
         """
         Update a single Streetview Service by service name
         :param user: User
@@ -99,106 +98,106 @@ class StreetviewService:
         :param data: Dict
         :return: Streetview
         """
-        sv = StreetviewService.getByService(user, service)
+        sv = StreetviewService.getByService(database_session, user, service)
 
         for key, value in data.items():
             setattr(sv, key, value)
 
-        db_session.commit()
+        database_session.commit()
         return sv
 
     @staticmethod
-    def deleteByService(user: User, service: str):
+    def deleteByService(database_session, user: User, service: str):
         """
         Delete a single Streetview Service by service name
         :param user: User
         :param service: str
         :return: None
         """
-        sv = StreetviewService.getByService(user, service)
-        db_session.delete(sv)
-        db_session.commit()
+        sv = StreetviewService.getByService(database_session, user, service)
+        database_session.delete(sv)
+        database_session.commit()
 
     @staticmethod
-    def delete(id: int) -> None:
+    def delete(database_session, id: int) -> None:
         """
         Delete a Streetview object.
         :param id: int
         :return: None
         """
-        sv = StreetviewService.get(id)
-        db_session.delete(sv)
-        db_session.commit()
+        sv = StreetviewService.get(database_session, id)
+        database_session.delete(sv)
+        database_session.commit()
 
     @staticmethod
-    def getOrganization(id: int) -> StreetviewOrganization:
+    def getOrganization(database_session, id: int) -> StreetviewOrganization:
         """
         Get a Streetview Organization object
         :param id: int
         :return: StreetviewOrganization
         """
-        return db_session.query(StreetviewOrganization).get(id)
+        return database_session.query(StreetviewOrganization).get(id)
 
     @staticmethod
-    def getAllOrganizations(user: User, service: str) -> List[StreetviewOrganization]:
+    def getAllOrganizations(database_session, user: User, service: str) -> List[StreetviewOrganization]:
         """
         Get all the Streetview Organization objects for a service.
         :param user: User
         :param service: str
         :return: List[StreetviewOrganization]
         """
-        sv = StreetviewService.getByService(user, service)
+        sv = StreetviewService.getByService(database_session, user, service)
         return sv.organizations
 
     @staticmethod
-    def createOrganization(user: User, service: str, data: Dict) -> StreetviewOrganization:
+    def createOrganization(database_session, user: User, service: str, data: Dict) -> StreetviewOrganization:
         """
         Create a Streetview Organization object
         :param service: str
         :param data: Dict
         :return: StreetviewOrganization
         """
-        sv = StreetviewService.getByService(user, service)
+        sv = StreetviewService.getByService(database_session, user, service)
         svo = StreetviewOrganization()
         svo.streetview_id = sv.id
         svo.key = data.get('key')
         svo.name = data.get('name')
         svo.slug = data.get('slug')
-        db_session.add(svo)
-        db_session.commit()
+        database_session.add(svo)
+        database_session.commit()
 
         return svo
 
     @staticmethod
-    def updateOrganization(id: int, data: Dict) -> StreetviewOrganization:
+    def updateOrganization(database_session, id: int, data: Dict) -> StreetviewOrganization:
         """
         Update a Streetview Organization object
         :param id: int
         :param data: Dict
         :return: StreetviewOrganization
         """
-        svo = StreetviewService.getOrganization(id)
+        svo = StreetviewService.getOrganization(database_session, id)
 
         for key, value in data.items():
             setattr(svo, key, value)
 
-        db_session.commit()
+        database_session.commit()
 
         return svo
 
     @staticmethod
-    def deleteOrganization(id: int):
+    def deleteOrganization(database_session, id: int):
         """
         Delete a Streetview Organization object
         :param id: int
         :return: None
         """
-        svo = StreetviewService.getOrganization(id)
-        db_session.delete(svo)
-        db_session.commit()
+        svo = StreetviewService.getOrganization(database_session, id)
+        database_session.delete(svo)
+        database_session.commit()
 
     @staticmethod
-    def createInstance(streetview_id: int, system_id: str, path: str) -> StreetviewInstance:
+    def createInstance(database_session, streetview_id: int, system_id: str, path: str) -> StreetviewInstance:
         """
         Create a Streetview Instance object.
         :param streetview_id: int
@@ -210,31 +209,31 @@ class StreetviewService:
         svi.streetview_id = streetview_id
         svi.path = path
         svi.system_id = system_id
-        db_session.add(svi)
-        db_session.commit()
+        database_session.add(svi)
+        database_session.commit()
 
         return svi
 
     @staticmethod
-    def getInstances(projectId: int) -> List[StreetviewInstance]:
-        proj = db_session.query(Project).get(projectId)
+    def getInstances(database_session, projectId: int) -> List[StreetviewInstance]:
+        proj = database_session.query(Project).get(projectId)
         return proj.streetview_instances
 
     @staticmethod
-    def addInstanceToProject(projectId: int, streetview_instance_id: int) -> None:
-        proj = db_session.query(Project).get(projectId)
-        streetview_instance = db_session.query(StreetviewInstance).get(streetview_instance_id)
+    def addInstanceToProject(database_session, projectId: int, streetview_instance_id: int) -> None:
+        proj = database_session.query(Project).get(projectId)
+        streetview_instance = database_session.query(StreetviewInstance).get(streetview_instance_id)
         proj.streetview_instances.append(streetview_instance)
-        db_session.commit()
+        database_session.commit()
 
     @staticmethod
-    def sequenceFromFeature(featureId: int):
-        return db_session.query(StreetviewSequence)\
+    def sequenceFromFeature(database_session, featureId: int):
+        return database_session.query(StreetviewSequence)\
             .filter(StreetviewSequence.feature.id == featureId)\
             .first()
 
     @staticmethod
-    def getInstanceFromSystemPath(streetview_id: int, system_id: str, path: str) -> StreetviewInstance:
+    def getInstanceFromSystemPath(database_session, streetview_id: int, system_id: str, path: str) -> StreetviewInstance:
         """
         Get a Streetview instance object for a system and path.
         :param streetview_id: int
@@ -242,25 +241,25 @@ class StreetviewService:
         :param path: str
         :return: StreetviewInstance
         """
-        return db_session.query(StreetviewInstance)\
+        return database_session.query(StreetviewInstance)\
                          .filter(StreetviewInstance.streetview_id == streetview_id)\
                          .filter(StreetviewInstance.system_id == system_id)\
                          .filter(StreetviewInstance.path == path)\
                          .first()
 
     @staticmethod
-    def deleteInstance(id: int) -> None:
+    def deleteInstance(database_session, id: int) -> None:
         """
         Delete a Streetview Instance object.
         :param id: int
         :return: None
         """
-        sv = db_session.query(StreetviewInstance).get(id)
-        db_session.delete(sv)
-        db_session.commit()
+        sv = database_session.query(StreetviewInstance).get(id)
+        database_session.delete(sv)
+        database_session.commit()
 
     @staticmethod
-    def addSequenceToInstance(user: User, data: Dict) -> None:
+    def addSequenceToInstance(database_session, user: User, data: Dict) -> None:
         """
         Add Streetview Sequences with keys to an existing Streetview object.
         :param user: User
@@ -268,17 +267,18 @@ class StreetviewService:
         :return: None
         """
         dir = data['dir']
-        svi = StreetviewService.getInstanceFromSystemPath(data['streetviewId'], dir['system'], dir['path'])
+        svi = StreetviewService.getInstanceFromSystemPath(database_session, data['streetviewId'], dir['system'], dir['path'])
 
         if not svi:
-            svi = StreetviewService.createInstance(data['streetviewId'], dir['system'], dir['path'])
+            svi = StreetviewService.createInstance(database_session, data['streetviewId'], dir['system'], dir['path'])
 
-        sequence = StreetviewService.createSequence(streetview_instance=svi, sequence_id=data['sequenceId'], organization_id=data['organizationId'])
+        sequence = StreetviewService.createSequence(database_session, streetview_instance=svi, sequence_id=data['sequenceId'], organization_id=data['organizationId'])
         svi.sequences.append(sequence)
-        db_session.commit()
+        database_session.commit()
 
     @staticmethod
-    def createSequence(streetview_instance: StreetviewInstance,
+    def createSequence(database_session,
+                       streetview_instance: StreetviewInstance,
                        start_date: datetime=None,
                        end_date: datetime=None,
                        bbox: str=None,
@@ -306,55 +306,55 @@ class StreetviewService:
             seq.organization_id = organization_id
         if sequence_id:
             seq.sequence_id = sequence_id
-        db_session.add(seq)
-        db_session.commit()
+        database_session.add(seq)
+        database_session.commit()
         return seq
 
     @staticmethod
-    def getSequenceFromId(sequence_id: str) -> StreetviewSequence:
+    def getSequenceFromId(database_session, sequence_id: str) -> StreetviewSequence:
         """
         Get a Streetview Sequence by its sequence_id.
         :param sequence_id: str
         :return: StreetviewSequence
         """
-        sequence = db_session.query(StreetviewSequence)\
+        sequence = database_session.query(StreetviewSequence)\
             .filter(StreetviewSequence.sequence_id == sequence_id)\
             .first()
         return sequence
 
     @staticmethod
-    def getSequence(id: int) -> StreetviewSequence:
+    def getSequence(database_session, id: int) -> StreetviewSequence:
         """
         Get a Streetview Sequence by its id.
         :param id: int
         :return: StreetviewSequence
         """
-        sequence = db_session.query(StreetviewSequence).get(id)
+        sequence = database_session.query(StreetviewSequence).get(id)
         return sequence
 
     @staticmethod
-    def deleteSequence(id: int) -> None:
+    def deleteSequence(database_session, id: int) -> None:
         """
         Delete a Streetview Sequence by its id.
         :param id: int
         :return: None
         """
-        seq = db_session.query(StreetviewSequence).get(id)
-        db_session.delete(seq)
-        db_session.commit()
+        seq = database_session.query(StreetviewSequence).get(id)
+        database_session.delete(seq)
+        database_session.commit()
 
     @staticmethod
-    def updateSequence(id: int, data: Dict) -> StreetviewSequence:
+    def updateSequence(database_session, id: int, data: Dict) -> StreetviewSequence:
         """
         Update a Streetview Sequence.
         :param sequence_id: int
         :param data: Dict
         :return: StreetviewSequence
         """
-        sequence = StreetviewService.getSequence(id)
+        sequence = StreetviewService.getSequence(database_session, id)
 
         for key, value in data.items():
             setattr(sequence, key, value)
-        db_session.commit()
+        database_session.commit()
 
         return sequence

--- a/geoapi/services/users.py
+++ b/geoapi/services/users.py
@@ -1,11 +1,10 @@
 from geoapi.models import User, Project, ProjectUser
-from geoapi.db import db_session
 
 
 class UserService:
 
     @staticmethod
-    def create(username: str, tenant: str, jwt: str = None) -> User:
+    def create(database_session, username: str, tenant: str, jwt: str = None) -> User:
         """
 
         :rtype: User
@@ -13,31 +12,31 @@ class UserService:
         u = User(username=username, tenant_id=tenant)
         if jwt:
             u.jwt = jwt
-        db_session.add(u)
-        db_session.commit()
+        database_session.add(u)
+        database_session.commit()
         return u
 
     @staticmethod
-    def getOrCreateUser(username: str, tenant: str) -> User:
-        user = UserService.getUser(username, tenant)
+    def getOrCreateUser(database_session, username: str, tenant: str) -> User:
+        user = UserService.getUser(database_session, username, tenant)
         if not user:
-            user = UserService.create(username, tenant)
+            user = UserService.create(database_session, username, tenant)
         return user
 
     @staticmethod
-    def getUser(username: str, tenant: str) -> User:
-        return db_session.query(User)\
+    def getUser(database_session, username: str, tenant: str) -> User:
+        return database_session.query(User)\
             .filter(User.username == username)\
             .filter(User.tenant_id == tenant)\
             .first()
 
     @staticmethod
-    def get(userId: int) -> User:
-        return db_session.query(User).get(userId)
+    def get(database_session, userId: int) -> User:
+        return database_session.query(User).get(userId)
 
     @staticmethod
-    def canAccess(user: User, projectId: int) -> bool:
-        up = db_session.query(ProjectUser)\
+    def canAccess(database_session, user: User, projectId: int) -> bool:
+        up = database_session.query(ProjectUser)\
             .join(Project)\
             .filter(ProjectUser.user_id == user.id)\
             .filter(Project.tenant_id == user.tenant_id)\
@@ -47,8 +46,8 @@ class UserService:
         return False
 
     @staticmethod
-    def is_admin_or_creator(user: User, projectId: int) -> bool:
-        up = db_session.query(ProjectUser) \
+    def is_admin_or_creator(database_session, user: User, projectId: int) -> bool:
+        up = database_session.query(ProjectUser) \
             .join(Project) \
             .filter(ProjectUser.user_id == user.id) \
             .filter(Project.tenant_id == user.tenant_id) \
@@ -58,6 +57,6 @@ class UserService:
         return False
 
     @staticmethod
-    def setJWT(user: User, token: str) -> None:
+    def setJWT(database_session, user: User, token: str) -> None:
         user.jwt = token
-        db_session.commit()
+        database_session.commit()

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -337,7 +337,8 @@ def import_from_files_from_path(session, tenant_id: str, userId: int, systemId: 
                 import_state = ImportState.SUCCESS
             except Exception as e:
                 logger.error(
-                    "Could not import for user:{} from agave:{}/{}".format(user.username, systemId, path))
+                    f"Could not import for user:{user.username} from agave:{systemId}/{item_system_path} "
+                    f"(while recursively importing files from {systemId}/{path})")
                 NotificationsService.create(session, user, "error", "Error importing {f}".format(f=item_system_path))
                 import_state = ImportState.FAILURE if e is not AgaveFileGetError else ImportState.RETRYABLE_FAILURE
             if import_state != ImportState.RETRYABLE_FAILURE:

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -233,7 +233,7 @@ def import_from_agave(tenant_id: str, userId: int, systemId: str, path: str, pro
     Recursively import files from a system/path.
     """
     with create_task_session() as session:
-        import_from_files_from_path(session, tenant_id, userId, systemId, str, projectId)
+        import_from_files_from_path(session, tenant_id, userId, systemId, path, projectId)
 
 
 def import_from_files_from_path(session, tenant_id: str, userId: int, systemId: str, path: str, projectId: int):

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -227,12 +227,12 @@ def import_from_agave(tenant_id: str, userId: int, systemId: str, path: str, pro
     """
     Recursively import files from a system/path.
 
-    If file has already been imported (i.e. during a previously call), we don't re-import it. Likewise,
+    If file has already been imported (i.e. during a previous call), we don't re-import it. Likewise,
     if we have previously failed at importing a file, we do not retry to import the file (unless it was an error like
     file-access where it makes sense to retry at a later time).
 
     Files located in /Rapp folder (i.e. created by the RAPP app) are handled differently as their location data is not
-    contained in specific-file-format meta data (e.g. exif for images) but instead the location is stored in Tapis
+    contained in specific-file-format metadata (e.g. exif for images) but instead the location is stored in Tapis
     metadata.
 
     This method is called by refresh_observable_projects()

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -114,8 +114,9 @@ def import_file_from_agave(userId: int, systemId: str, path: str, projectId: int
 
             temp_file = client.getFile(systemId, path)
             temp_file.filename = Path(path).name
-            additional_files = get_additional_files(session, systemId, path, client)
-            FeaturesService.fromFileObj(session, projectId, temp_file, {}, original_path=path, additional_files=additional_files)
+            additional_files = get_additional_files(systemId, path, client)
+            FeaturesService.fromFileObj(session, projectId, temp_file, {},
+                                        original_path=path, additional_files=additional_files)
             NotificationsService.create(session, user, "success", "Imported {f}".format(f=path))
             temp_file.close()
         except Exception as e:  # noqa: E722

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -3,7 +3,6 @@ import concurrent
 from pathlib import Path
 import concurrent.futures
 from enum import Enum
-import json
 import time
 import datetime
 from celery import uuid as celery_uuid
@@ -19,7 +18,7 @@ from geoapi.services.imports import ImportsService
 from geoapi.services.vectors import SHAPEFILE_FILE_ADDITIONAL_FILES
 import geoapi.services.point_cloud as pointcloud
 from geoapi.tasks.lidar import convert_to_potree, check_point_cloud, get_point_cloud_info
-from geoapi.db import db_session
+from geoapi.db import create_task_session
 from geoapi.services.notifications import NotificationsService
 from geoapi.services.users import UserService
 
@@ -108,122 +107,135 @@ def import_file_from_agave(userId: int, systemId: str, path: str, projectId: int
 
     Note: all geolocation information is expected to be embedded in the imported file.
     """
-    user = db_session.query(User).get(userId)
-    client = AgaveUtils(user.jwt)
-    try:
-        tmpFile = client.getFile(systemId, path)
-        tmpFile.filename = Path(path).name
-        additional_files = get_additional_files(systemId, path, client)
-        FeaturesService.fromFileObj(projectId, tmpFile, {}, original_path=path, additional_files=additional_files)
-        NotificationsService.create(user, "success", "Imported {f}".format(f=path))
-        tmpFile.close()
-    except Exception as e:  # noqa: E722
-        db_session.rollback()
-        logger.exception("Could not import file from agave: {} :: {}".format(systemId, path))
-        NotificationsService.create(user, "error", "Error importing {f}".format(f=path))
-        raise e
+    with create_task_session() as session:
+        try:
+            user = session.query(User).get(userId)
+            client = AgaveUtils(user.jwt)
+
+            temp_file = client.getFile(systemId, path)
+            temp_file.filename = Path(path).name
+            additional_files = get_additional_files(session, systemId, path, client)
+            FeaturesService.fromFileObj(session, projectId, temp_file, {}, original_path=path, additional_files=additional_files)
+            NotificationsService.create(session, user, "success", "Imported {f}".format(f=path))
+            temp_file.close()
+        except Exception as e:  # noqa: E722
+            logger.exception("Could not import file from agave: {} :: {}".format(systemId, path))
+            NotificationsService.create(session, user, "error", "Error importing {f}".format(f=path))
+            raise e
 
 
-def _update_point_cloud_task(pointCloudId: int, description: str = None, status: str = None):
-    task = pointcloud.PointCloudService.get(pointCloudId).task
+def _update_point_cloud_task(database_session, pointCloudId: int, description: str = None, status: str = None):
+    task = pointcloud.PointCloudService.get(database_session, pointCloudId).task
     if description is not None:
         task.description = description
     if status is not None:
         task.status = status
-    try:
-        db_session.add(task)
-        db_session.commit()
-    except Exception:
-        db_session.rollback()
-        raise
+    database_session.add(task)
+    database_session.commit()
 
 
 @app.task(rate_limit="1/s")
 def import_point_clouds_from_agave(userId: int, files, pointCloudId: int):
-    user = db_session.query(User).get(userId)
-    client = AgaveUtils(user.jwt)
+    with create_task_session() as session:
+        user = session.query(User).get(userId)
+        client = AgaveUtils(user.jwt)
 
-    point_cloud = pointcloud.PointCloudService.get(pointCloudId)
-    celery_task_id = celery_uuid()
+        point_cloud = pointcloud.PointCloudService.get(session, pointCloudId)
+        celery_task_id = celery_uuid()
 
-    task = Task()
-    task.process_id = celery_task_id
-    task.status = "RUNNING"
+        # this initial geoapi.model.Task setup should probably be moved out of the celery task and performed
+        # in the request processing (i.e. in ProjectPointCloudsFileImportResource) so that a task can be returned in the
+        # request. See https://jira.tacc.utexas.edu/browse/WG-85
+        task = Task()
+        task.process_id = celery_task_id
+        task.status = "RUNNING"
 
-    point_cloud.task = task
-    db_session.add(point_cloud)
+        point_cloud.task = task
+        session.add(point_cloud)
+        session.add(task)
+        logger.error("committing")
+        session.commit()
+        logger.error("done committing")
 
-    new_asset_files = []
-    failed_message = None
-    for file in files:
-        _update_point_cloud_task(pointCloudId,
-                                 description="Importing file ({}/{})".format(len(new_asset_files) + 1, len(files)))
+        new_asset_files = []
+        failed_message = None
+        for file in files:
+            _update_point_cloud_task(session,
+                                     pointCloudId,
+                                     description="Importing file ({}/{})".format(len(new_asset_files) + 1, len(files)))
 
-        NotificationsService.create(user, "success", task.description)
+            NotificationsService.create(session, user, "success", task.description)
 
-        system_id = file["system"]
-        path = file["path"]
+            system_id = file["system"]
+            path = file["path"]
+
+            try:
+                tmp_file = client.getFile(system_id, path)
+                tmp_file.filename = Path(path).name
+                file_path = pointcloud.PointCloudService.putPointCloudInOriginalsFileDir(point_cloud.path,
+                                                                                         tmp_file,
+                                                                                         tmp_file.filename)
+                tmp_file.close()
+
+                # save file path as we might need to delete it if there is a problem
+                new_asset_files.append(file_path)
+
+                # check if file is okay
+                check_point_cloud(file_path)
+
+            except InvalidCoordinateReferenceSystem:
+                logger.error("Could not import point cloud file due to missing"
+                             " coordinate reference system: {}:{}".format(system_id, path))
+                failed_message = 'Error importing {}: missing coordinate reference system'.format(path)
+            except Exception as e:
+                logger.error("Could not import point cloud file for user:{} from tapis: {}/{} : {}".format(user.username,
+                                                                                                           system_id,
+                                                                                                           path, e))
+                failed_message = 'Unknown error importing {}:{}'.format(system_id, path)
+
+            if failed_message:
+                for file_path in new_asset_files:
+                    logger.info("removing {}".format(file_path))
+                    os.remove(file_path)
+                _update_point_cloud_task(session, pointCloudId, description=failed_message, status="FAILED")
+                NotificationsService.create(session, user, "error", failed_message)
+                return
+
+        _update_point_cloud_task(session, pointCloudId, description="Running potree converter", status="RUNNING")
+
+        point_cloud.files_info = get_point_cloud_info(session, pointCloudId)
+
+        session.add(point_cloud)
+        session.commit()
+
+        NotificationsService.create(session,
+                                    user,
+                                    "success",
+                                    "Running potree converter (for point cloud {}).".format(pointCloudId))
 
         try:
-            tmp_file = client.getFile(system_id, path)
-            tmp_file.filename = Path(path).name
-            file_path = pointcloud.PointCloudService.putPointCloudInOriginalsFileDir(point_cloud.path,
-                                                                                     tmp_file,
-                                                                                     tmp_file.filename)
-            tmp_file.close()
-
-            # save file path as we might need to delete it if there is a problem
-            new_asset_files.append(file_path)
-
-            # check if file is okay
-            check_point_cloud.apply(args=[file_path], throw=True)
-
-        except InvalidCoordinateReferenceSystem:
-            logger.error("Could not import point cloud file due to missing"
-                         " coordinate reference system: {}:{}".format(system_id, path))
-            failed_message = 'Error importing {}: missing coordinate reference system'.format(path)
-        except Exception as e:
-            logger.error("Could not import point cloud file for user:{} from tapis: {}/{} : {}".format(user.username,
-                                                                                                       system_id,
-                                                                                                       path, e))
-            failed_message = 'Unknown error importing {}:{}'.format(system_id, path)
-
-        if failed_message:
-            for file_path in new_asset_files:
-                logger.info("removing {}".format(file_path))
-                os.remove(file_path)
-            _update_point_cloud_task(pointCloudId, description=failed_message, status="FAILED")
-            NotificationsService.create(user, "error", failed_message)
+            convert_to_potree(pointCloudId)
+            NotificationsService.create(session,
+                                        user,
+                                        "success",
+                                        "Completed potree converter (for point cloud {}).".format(pointCloudId))
+        except:  # noqa: E722
+            logger.exception("point cloud:{} conversion failed for user:{}".format(pointCloudId, user.username))
+            _update_point_cloud_task(session, pointCloudId, description="", status="FAILED")
+            NotificationsService.create(session, user, "error", "Processing failed for point cloud ({})!".format(pointCloudId))
             return
-
-    _update_point_cloud_task(pointCloudId, description="Running potree converter", status="RUNNING")
-
-    point_cloud.files_info = json.dumps(get_point_cloud_info(pointCloudId))
-    try:
-        db_session.add(point_cloud)
-        db_session.add(task)
-        db_session.commit()
-    except:  # noqa: E722
-        db_session.rollback()
-        raise
-    NotificationsService.create(user,
-                                "success",
-                                "Running potree converter (for point cloud {}).".format(pointCloudId))
-
-    try:
-        convert_to_potree.apply(args=[pointCloudId], task_id=celery_task_id, throw=True)
-        NotificationsService.create(user,
-                                    "success",
-                                    "Completed potree converter (for point cloud {}).".format(pointCloudId))
-    except:  # noqa: E722
-        logger.exception("point cloud:{} conversion failed for user:{}".format(pointCloudId, user.username))
-        _update_point_cloud_task(pointCloudId, description="", status="FAILED")
-        NotificationsService.create(user, "error", "Processing failed for point cloud ({})!".format(pointCloudId))
-        return
 
 
 @app.task(rate_limit="5/s")
 def import_from_agave(tenant_id: str, userId: int, systemId: str, path: str, projectId: int):
+    """
+    Recursively import files from a system/path.
+    """
+    with create_task_session() as session:
+        import_from_files_from_path(session, tenant_id, userId, systemId, str, projectId)
+
+
+def import_from_files_from_path(session, tenant_id: str, userId: int, systemId: str, path: str, projectId: int):
     """
     Recursively import files from a system/path.
 
@@ -237,8 +249,7 @@ def import_from_agave(tenant_id: str, userId: int, systemId: str, path: str, pro
 
     This method is called by refresh_observable_projects()
     """
-
-    user = db_session.query(User).get(userId)
+    user = session.query(User).get(userId)
     client = AgaveUtils(user.jwt)
     logger.info("Importing for project:{} directory:{}/{} for user:{}".format(projectId,
                                                                               systemId,
@@ -248,7 +259,7 @@ def import_from_agave(tenant_id: str, userId: int, systemId: str, path: str, pro
         listing = client.listing(systemId, path)
     except AgaveListingError:
         logger.exception(f"Unable to perform file listing on {systemId}/{path} when importing for project:{projectId}")
-        NotificationsService.create(user, "error", f"Error importing as unable to access {systemId}/{path}")
+        NotificationsService.create(session, user, "error", f"Error importing as unable to access {systemId}/{path}")
         return
 
     # First item is always a reference to self
@@ -256,22 +267,22 @@ def import_from_agave(tenant_id: str, userId: int, systemId: str, path: str, pro
     filenames_in_directory = [str(f.path) for f in files_in_directory]
     for item in files_in_directory:
         if item.type == "dir" and not str(item.path).endswith("/.Trash"):
-            import_from_agave(tenant_id, userId, systemId, item.path, projectId)
+            import_from_files_from_path(session, tenant_id, userId, systemId, item.path, projectId)
         # skip any junk files that are not allowed
         if item.path.suffix.lower().lstrip('.') not in FeaturesService.ALLOWED_EXTENSIONS:
             continue
         else:
+            item_system_path = os.path.join(item.system, str(item.path).lstrip("/"))
             try:
                 # first check if there already is a file in the DB
-                item_system_path = os.path.join(item.system, str(item.path).lstrip("/"))
-                target_file = ImportsService.getImport(projectId, systemId, str(item.path))
+                target_file = ImportsService.getImport(session, projectId, systemId, str(item.path))
                 if target_file:
                     logger.debug(f"Already imported {item_system_path} for project:{projectId} so skipping. "
                                  f"The original import was on {target_file.created} and "
                                  f"successful_import={target_file.successful_import}")
                     continue
 
-                # If its a RApp project folder, grab the metadata from tapis meta service
+                # If it is a RApp project folder, grab the metadata from tapis meta service
                 if is_member_of_rapp_project_folder(item_system_path):
                     logger.info("RApp: importing:{} for user:{}".format(item_system_path, user.username))
                     if item.path.suffix.lower().lstrip(
@@ -298,38 +309,36 @@ def import_from_agave(tenant_id: str, userId: int, systemId: str, path: str, pro
                         logger.info("No geolocation for:{}; skipping".format(item_system_path))
                         continue
                     lat, lon = _parse_rapid_geolocation(geolocation)
-                    tmpFile = client.getFile(systemId, item.path)
-                    feat = FeaturesService.fromLatLng(projectId, lat, lon, {})
+                    tmp_file = client.getFile(systemId, item.path)
+                    feat = FeaturesService.fromLatLng(session, projectId, lat, lon, {})
                     feat.properties = meta
-                    db_session.add(feat)
-                    tmpFile.filename = Path(item.path).name
+                    session.add(feat)
+                    tmp_file.filename = Path(item.path).name
                     try:
-                        FeaturesService.createFeatureAsset(projectId, feat.id, tmpFile, original_path=item_system_path)
+                        FeaturesService.createFeatureAsset(session, projectId, feat.id, tmp_file, original_path=item_system_path)
                     except:  # noqa: E722
                         # remove newly-created placeholder feature if we fail to create an asset
-                        FeaturesService.delete(feat.id)
+                        FeaturesService.delete(session, feat.id)
                         raise RuntimeError("Unable to create feature asset")
-                    NotificationsService.create(user, "success", "Imported {f}".format(f=item_system_path))
-                    tmpFile.close()
+                    NotificationsService.create(session, user, "success", "Imported {f}".format(f=item_system_path))
+                    tmp_file.close()
                 elif item.path.suffix.lower().lstrip('.') in FeaturesService.ALLOWED_GEOSPATIAL_EXTENSIONS:
                     logger.info("importing:{} for user:{}".format(item_system_path, user.username))
-                    tmpFile = client.getFile(systemId, item.path)
-                    tmpFile.filename = Path(item.path).name
+                    tmp_file = client.getFile(systemId, item.path)
+                    tmp_file.filename = Path(item.path).name
                     additional_files = get_additional_files(systemId, item.path, client, filenames_in_directory)
-                    FeaturesService.fromFileObj(projectId, tmpFile, {},
+                    FeaturesService.fromFileObj(session, projectId, tmp_file, {},
                                                 original_path=item_system_path, additional_files=additional_files)
-                    NotificationsService.create(user, "success", "Imported {f}".format(f=item_system_path))
-                    tmpFile.close()
+                    NotificationsService.create(session, user, "success", "Imported {f}".format(f=item_system_path))
+                    tmp_file.close()
                 else:
                     continue
                 import_state = ImportState.SUCCESS
             except Exception as e:
-                db_session.rollback()
                 logger.error(
                     "Could not import for user:{} from agave:{}/{}".format(user.username, systemId, path))
-                NotificationsService.create(user, "error", "Error importing {f}".format(f=item_system_path))
+                NotificationsService.create(session, user, "error", "Error importing {f}".format(f=item_system_path))
                 import_state = ImportState.FAILURE if e is not AgaveFileGetError else ImportState.RETRYABLE_FAILURE
-                logger.exception(e)
             if import_state != ImportState.RETRYABLE_FAILURE:
                 try:
                     successful = True if import_state == ImportState.SUCCESS else False
@@ -339,77 +348,82 @@ def import_from_agave(tenant_id: str, userId: int, systemId: str, path: str, pro
                                                                     path=str(item.path),
                                                                     lastUpdated=item.lastModified,
                                                                     successful_import=successful)
-                    db_session.add(target_file)
-                    db_session.commit()
+                    session.add(target_file)
+                    session.commit()
                 except Exception:  # noqa: E722
                     logger.exception(f"Failed to create db entry (imported_file)"
                                      f"for projectId:{projectId}  {systemId}/{path}")
-                    db_session.rollback()
+                    raise
 
 
 @app.task()
 def refresh_observable_projects():
+    """
+    Refresh all observable projects
+    """
     start_time = time.time()
-    try:
-        logger.info("Starting to refresh all observable projects")
-        obs = db_session.query(ObservableDataProject).all()
-        for i, o in enumerate(obs):
-            try:
-                # we need a user with a jwt for importing
-                importing_user = next((u for u in o.project.users if u.jwt))
-                logger.info(f"Refreshing observable project ({i}/{len(obs)}): observer:{importing_user} "
-                            f"system:{o.system_id} path:{o.path} project:{o.project.id}")
+    with create_task_session() as session:
+        try:
+            logger.info("Starting to refresh all observable projects")
+            obs = session.query(ObservableDataProject).all()
+            for i, o in enumerate(obs):
+                try:
+                    # we need a user with a jwt for importing
+                    importing_user = next((u for u in o.project.users if u.jwt))
+                    logger.info(f"Refreshing observable project ({i}/{len(obs)}): observer:{importing_user} "
+                                f"system:{o.system_id} path:{o.path} project:{o.project.id}")
 
-                # we need to add any users who have been added to the project/system or update if their admin-status
-                # has changed
-                current_users = set([SystemUser(username=u.user.username, admin=u.admin) for u in o.project.project_users])
-                updated_users = set(get_system_users(o.project.tenant_id, importing_user.jwt, o.system_id))
+                    # we need to add any users who have been added to the project/system or update if their admin-status
+                    # has changed
+                    current_users = set([SystemUser(username=u.user.username, admin=u.admin)
+                                         for u in o.project.project_users])
+                    updated_users = set(get_system_users(o.project.tenant_id, importing_user.jwt, o.system_id))
 
-                current_creator = db_session.query(ProjectUser)\
-                    .filter(ProjectUser.project_id == o.id)\
-                    .filter(ProjectUser.creator is True).one_or_none()
+                    current_creator = session.query(ProjectUser)\
+                        .filter(ProjectUser.project_id == o.id)\
+                        .filter(ProjectUser.creator is True).one_or_none()
 
-                if current_users != updated_users:
-                    logger.info("Updating users from:{} to:{}".format(current_users, updated_users))
+                    if current_users != updated_users:
+                        logger.info("Updating users from:{} to:{}".format(current_users, updated_users))
 
-                    # set project users
-                    o.project.users = [UserService.getOrCreateUser(u.username, tenant=o.project.tenant_id) for u in updated_users]
-                    db_session.add(o)
-                    db_session.commit()
+                        # set project users
+                        o.project.users = [UserService.getOrCreateUser(session, u.username, tenant=o.project.tenant_id)
+                                           for u in updated_users]
+                        session.add(o)
+                        session.commit()
 
-                    updated_users_to_admin_status = {u.username: u for u in updated_users}
-                    logger.info("current_users_to_admin_status:{}".format(updated_users_to_admin_status))
-                    for u in o.project.project_users:
-                        u.admin = updated_users_to_admin_status[u.user.username].admin
-                        db_session.add(u)
-                    db_session.commit()
+                        updated_users_to_admin_status = {u.username: u for u in updated_users}
+                        logger.info("current_users_to_admin_status:{}".format(updated_users_to_admin_status))
+                        for u in o.project.project_users:
+                            u.admin = updated_users_to_admin_status[u.user.username].admin
+                            session.add(u)
+                        session.commit()
 
-                    if current_creator:
-                        # reset the creator by finding that updated user again and updating it.
-                        current_creator = db_session.query(ProjectUser)\
-                            .filter(ProjectUser.project_id == o.id)\
-                            .filter(ProjectUser.user_id == current_creator.user_id)\
-                            .one_or_none()
                         if current_creator:
-                            current_creator.creator = True
-                            db_session.add(current_creator)
-                            db_session.commit()
+                            # reset the creator by finding that updated user again and updating it.
+                            current_creator = session.query(ProjectUser)\
+                                .filter(ProjectUser.project_id == o.id)\
+                                .filter(ProjectUser.user_id == current_creator.user_id)\
+                                .one_or_none()
+                            if current_creator:
+                                current_creator.creator = True
+                                session.add(current_creator)
+                                session.commit()
 
-                # perform the importing
-                if o.watch_content:
-                    import_from_agave(o.project.tenant_id, importing_user.id, o.system_id, o.path, o.project.id)
-            except Exception:  # noqa: E722
-                logger.exception(f"Unhandled exception when importing observable project:{o.project.id}")
-                db_session.rollback()
-
-        total_time = time.time() - start_time
-        logger.info("refresh_observable_projects completed. "
-                    "Elapsed time {}".format(datetime.timedelta(seconds=total_time)))
-    except Exception:  # noqa: E722
-        logger.error("Error when trying to get list of observable projects; this is unexpected and should be reported"
-                     "(i.e. https://jira.tacc.utexas.edu/browse/WG-131).")
-        db_session.rollback()
-        raise
+                    # perform the importing
+                    if o.watch_content:
+                        import_from_files_from_path(session, o.project.tenant_id, importing_user.id, o.system_id, o.path, o.project.id)
+                except Exception:  # noqa: E722
+                    logger.exception(f"Unhandled exception when importing observable project:{o.project.id}. "
+                                     "Performing rollback of current database transaction")
+                    session.rollback()
+            total_time = time.time() - start_time
+            logger.info("refresh_observable_projects completed. "
+                        "Elapsed time {}".format(datetime.timedelta(seconds=total_time)))
+        except Exception:  # noqa: E722
+            logger.error("Error when trying to get list of observable projects; this is unexpected and should be reported"
+                         "(i.e. https://jira.tacc.utexas.edu/browse/WG-131).")
+            raise
 
 
 if __name__ == "__main__":

--- a/geoapi/tasks/lidar.py
+++ b/geoapi/tasks/lidar.py
@@ -11,7 +11,7 @@ from geoapi.log import logging
 from geoapi.utils.lidar import getProj4, get_bounding_box_2d
 from geoapi.utils import geometries
 from geoapi.celery_app import app
-from geoapi.db import db_session
+from geoapi.db import create_task_session
 from geoapi.models import Task
 from geoapi.utils.assets import make_project_asset_dir, get_asset_path, get_asset_relative_path
 
@@ -30,7 +30,6 @@ def get_point_cloud_files(path):
     return input_files
 
 
-@app.task()
 def check_point_cloud(file_path: str) -> None:
     """
     Check point cloud file that it has required info
@@ -42,8 +41,7 @@ def check_point_cloud(file_path: str) -> None:
     getProj4(file_path)
 
 
-@app.task()
-def get_point_cloud_info(pointCloudId: int) -> dict:
+def get_point_cloud_info(database_session, pointCloudId: int) -> dict:
     """
     Get info on las files
     :param pointCloudId: int
@@ -51,7 +49,7 @@ def get_point_cloud_info(pointCloudId: int) -> dict:
     """
     from geoapi.services.point_cloud import PointCloudService
 
-    point_cloud = PointCloudService.get(pointCloudId)
+    point_cloud = PointCloudService.get(database_session, pointCloudId)
     path_to_original_point_clouds = get_asset_path(point_cloud.path, PointCloudService.ORIGINAL_FILES_DIR)
     input_files = get_point_cloud_files(path_to_original_point_clouds)
 
@@ -61,11 +59,12 @@ def get_point_cloud_info(pointCloudId: int) -> dict:
 class PointCloudProcessingTask(celery.Task):
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         logger.info("Task ({}, point cloud {}) failed: {}".format(task_id, args, exc))
-        failed_task = db_session.query(Task).filter(Task.process_id == task_id).first()
-        failed_task.status = "FAILED"
-        failed_task.description = ""
-        db_session.add(failed_task)
-        db_session.commit()
+        with create_task_session() as session:
+            failed_task = session.query(Task).filter(Task.process_id == task_id).first()
+            failed_task.status = "FAILED"
+            failed_task.description = ""
+            session.add(failed_task)
+            session.commit()
 
 
 @app.task(bind=True, base=PointCloudProcessingTask)
@@ -78,72 +77,68 @@ def convert_to_potree(self, pointCloudId: int) -> None:
     from geoapi.models import Feature, FeatureAsset
     from geoapi.services.point_cloud import PointCloudService
 
-    point_cloud = PointCloudService.get(pointCloudId)
+    with create_task_session() as session:
+        point_cloud = PointCloudService.get(session, pointCloudId)
 
-    path_to_original_point_clouds = get_asset_path(point_cloud.path, PointCloudService.ORIGINAL_FILES_DIR)
-    path_temp_processed_point_cloud_path = get_asset_path(point_cloud.path, PointCloudService.PROCESSED_DIR)
+        path_to_original_point_clouds = get_asset_path(point_cloud.path, PointCloudService.ORIGINAL_FILES_DIR)
+        path_temp_processed_point_cloud_path = get_asset_path(point_cloud.path, PointCloudService.PROCESSED_DIR)
 
-    input_files = [get_asset_path(path_to_original_point_clouds, file)
-                   for file in os.listdir(path_to_original_point_clouds)
-                   if pathlib.Path(file).suffix.lstrip('.').lower() in PointCloudService.LIDAR_FILE_EXTENSIONS]
+        input_files = [get_asset_path(path_to_original_point_clouds, file)
+                       for file in os.listdir(path_to_original_point_clouds)
+                       if pathlib.Path(file).suffix.lstrip('.').lower() in PointCloudService.LIDAR_FILE_EXTENSIONS]
 
-    outline = get_bounding_box_2d(input_files)
+        outline = get_bounding_box_2d(input_files)
 
-    command = [
-        "PotreeConverter",
-        "--verbose",
-        "-i",
-        path_to_original_point_clouds,
-        "-o",
-        path_temp_processed_point_cloud_path,
-        "--overwrite",
-        "--generate-page",
-        "index"
-    ]
-    if point_cloud.conversion_parameters:
-        command.extend(point_cloud.conversion_parameters.split())
-    logger.info("Processing point cloud (#{}):  {}".format(pointCloudId, " ".join(command)))
-    subprocess.run(command, check=True, capture_output=True, text=True)
+        command = [
+            "PotreeConverter",
+            "--verbose",
+            "-i",
+            path_to_original_point_clouds,
+            "-o",
+            path_temp_processed_point_cloud_path,
+            "--overwrite",
+            "--generate-page",
+            "index"
+        ]
+        if point_cloud.conversion_parameters:
+            command.extend(point_cloud.conversion_parameters.split())
+        logger.info("Processing point cloud (#{}):  {}".format(pointCloudId, " ".join(command)))
+        subprocess.run(command, check=True, capture_output=True, text=True)
 
-    # Create preview viewer html (with no menu and now nsf logo)
-    with open(os.path.join(path_temp_processed_point_cloud_path, "preview.html"), 'w+') as preview:
-        with open(os.path.join(path_temp_processed_point_cloud_path, "index.html"), 'r') as viewer:
-            content = viewer.read()
-            content = re.sub(r"<div class=\"nsf_logo\"(.+?)</div>", '', content, flags=re.DOTALL)
-            content = content.replace("viewer.toggleSidebar()", "$('.potree_menu_toggle').hide()")
-            preview.write(content)
+        # Create preview viewer html (with no menu and now nsf logo)
+        with open(os.path.join(path_temp_processed_point_cloud_path, "preview.html"), 'w+') as preview:
+            with open(os.path.join(path_temp_processed_point_cloud_path, "index.html"), 'r') as viewer:
+                content = viewer.read()
+                content = re.sub(r"<div class=\"nsf_logo\"(.+?)</div>", '', content, flags=re.DOTALL)
+                content = content.replace("viewer.toggleSidebar()", "$('.potree_menu_toggle').hide()")
+                preview.write(content)
 
-    if point_cloud.feature_id:
-        feature = point_cloud.feature
-    else:
-        feature = Feature()
-        feature.project_id = point_cloud.project_id
+        if point_cloud.feature_id:
+            feature = point_cloud.feature
+        else:
+            feature = Feature()
+            feature.project_id = point_cloud.project_id
 
-        asset_uuid = uuid.uuid4()
-        base_filepath = make_project_asset_dir(point_cloud.project_id)
-        asset_path = os.path.join(base_filepath, str(asset_uuid))
-        fa = FeatureAsset(
-            uuid=asset_uuid,
-            asset_type="point_cloud",
-            path=get_asset_relative_path(asset_path),
-            display_path=point_cloud.description,
-            feature=feature
-        )
-        feature.assets.append(fa)
-        point_cloud.feature = feature
+            asset_uuid = uuid.uuid4()
+            base_filepath = make_project_asset_dir(point_cloud.project_id)
+            asset_path = os.path.join(base_filepath, str(asset_uuid))
+            fa = FeatureAsset(
+                uuid=asset_uuid,
+                asset_type="point_cloud",
+                path=get_asset_relative_path(asset_path),
+                display_path=point_cloud.description,
+                feature=feature
+            )
+            feature.assets.append(fa)
+            point_cloud.feature = feature
 
-    feature.the_geom = from_shape(geometries.convert_3D_2D(outline), srid=4326)
-    point_cloud.task.status = "FINISHED"
-    point_cloud.task.description = ""
+        feature.the_geom = from_shape(geometries.convert_3D_2D(outline), srid=4326)
+        point_cloud.task.status = "FINISHED"
+        point_cloud.task.description = ""
 
-    point_cloud_asset_path = get_asset_path(feature.assets[0].path)
-    shutil.rmtree(point_cloud_asset_path, ignore_errors=True)
-    shutil.move(path_temp_processed_point_cloud_path, point_cloud_asset_path)
-
-    try:
-        db_session.add(point_cloud)
-        db_session.add(feature)
-        db_session.commit()
-    except:  # noqa: E722
-        db_session.rollback()
-        raise
+        point_cloud_asset_path = get_asset_path(feature.assets[0].path)
+        shutil.rmtree(point_cloud_asset_path, ignore_errors=True)
+        shutil.move(path_temp_processed_point_cloud_path, point_cloud_asset_path)
+        session.add(point_cloud)
+        session.add(feature)
+        session.commit()

--- a/geoapi/tasks/uploads.py
+++ b/geoapi/tasks/uploads.py
@@ -1,8 +1,0 @@
-from typing import IO, Dict
-
-from geoapi.celery_app import app
-
-
-@app.task()
-def process_upload(projectId: int, fileObj: IO, meta: Dict):
-    pass

--- a/geoapi/tests/api_tests/test_feature_service.py
+++ b/geoapi/tests/api_tests/test_feature_service.py
@@ -8,19 +8,19 @@ from geoapi.utils.assets import get_project_asset_dir, get_asset_path
 
 
 def test_create_feature_fromLatLng(projects_fixture):
-    feature = FeaturesService.fromLatLng(projects_fixture.id, 10, 20, metadata={})
+    feature = FeaturesService.fromLatLng(db_session, projects_fixture.id, 10, 20, metadata={})
     assert len(feature.assets) == 0
     assert feature.id is not None
 
 
 def test_hazmapperv1_file_with_images(projects_fixture, hazmpperV1_file):
-    features = FeaturesService.fromGeoJSON(projects_fixture.id, hazmpperV1_file, metadata={})
+    features = FeaturesService.fromGeoJSON(db_session, projects_fixture.id, hazmpperV1_file, metadata={})
     assert len(features) == 2
     assert len(features[1].assets) == 1
 
 
 def test_insert_feature_geojson(projects_fixture, feature_properties_file_fixture):
-    features = FeaturesService.fromGeoJSON(projects_fixture.id, feature_properties_file_fixture, metadata={})
+    features = FeaturesService.fromGeoJSON(db_session, projects_fixture.id, feature_properties_file_fixture, metadata={})
     feature = features[0]
     assert len(features) == 1
     assert feature.project_id == projects_fixture.id
@@ -29,7 +29,7 @@ def test_insert_feature_geojson(projects_fixture, feature_properties_file_fixtur
 
 
 def test_insert_feature_collection(projects_fixture, geojson_file_fixture):
-    features = FeaturesService.fromGeoJSON(projects_fixture.id, geojson_file_fixture, metadata={})
+    features = FeaturesService.fromGeoJSON(db_session, projects_fixture.id, geojson_file_fixture, metadata={})
     for feature in features:
         assert feature.project_id == projects_fixture.id
     assert db_session.query(Feature).count() == 3
@@ -37,13 +37,13 @@ def test_insert_feature_collection(projects_fixture, geojson_file_fixture):
 
 
 def test_remove_feature(projects_fixture, feature_fixture):
-    FeaturesService.delete(feature_fixture.id)
+    FeaturesService.delete(db_session, feature_fixture.id)
     assert db_session.query(Feature).count() == 0
     assert not os.path.exists(get_project_asset_dir(feature_fixture.project_id))
 
 
 def test_create_feature_image(projects_fixture, image_file_fixture):
-    feature = FeaturesService.fromImage(projects_fixture.id, image_file_fixture, metadata={})
+    feature = FeaturesService.fromImage(db_session, projects_fixture.id, image_file_fixture, metadata={})
     assert feature.project_id == projects_fixture.id
     assert len(feature.assets) == 1
     assert db_session.query(Feature).count() == 1
@@ -54,7 +54,7 @@ def test_create_feature_image(projects_fixture, image_file_fixture):
 
 
 def test_create_feature_image_small_image(projects_fixture, image_small_DES_2176_fixture):
-    feature = FeaturesService.fromImage(projects_fixture.id, image_small_DES_2176_fixture, metadata={})
+    feature = FeaturesService.fromImage(db_session, projects_fixture.id, image_small_DES_2176_fixture, metadata={})
     assert feature.project_id == projects_fixture.id
     assert len(feature.assets) == 1
     assert db_session.query(Feature).count() == 1
@@ -65,8 +65,8 @@ def test_create_feature_image_small_image(projects_fixture, image_small_DES_2176
 
 
 def test_remove_feature_image(projects_fixture, image_file_fixture):
-    feature = FeaturesService.fromImage(projects_fixture.id, image_file_fixture, metadata={})
-    FeaturesService.delete(feature.id)
+    feature = FeaturesService.fromImage(db_session,  projects_fixture.id, image_file_fixture, metadata={})
+    FeaturesService.delete(db_session, feature.id)
 
     assert db_session.query(Feature).count() == 0
     assert db_session.query(FeatureAsset).count() == 0
@@ -74,7 +74,7 @@ def test_remove_feature_image(projects_fixture, image_file_fixture):
 
 
 def test_create_feature_image_asset(projects_fixture, feature_fixture, image_file_fixture):
-    feature = FeaturesService.createFeatureAsset(projects_fixture.id,
+    feature = FeaturesService.createFeatureAsset(db_session, projects_fixture.id,
                                                  feature_fixture.id,
                                                  FileStorage(image_file_fixture))
     assert feature.id == feature_fixture.id
@@ -86,17 +86,18 @@ def test_create_feature_image_asset(projects_fixture, feature_fixture, image_fil
 
 
 def test_remove_feature_image_asset(projects_fixture, feature_fixture, image_file_fixture):
-    feature = FeaturesService.createFeatureAsset(projects_fixture.id,
+    feature = FeaturesService.createFeatureAsset(db_session, projects_fixture.id,
                                                  feature_fixture.id,
                                                  FileStorage(image_file_fixture))
-    FeaturesService.delete(feature.id)
+    FeaturesService.delete(db_session, feature.id)
     assert db_session.query(Feature).count() == 0
     assert db_session.query(FeatureAsset).count() == 0
     assert len(os.listdir(get_project_asset_dir(feature.project_id))) == 0
 
 
 def test_create_feature_video_asset(projects_fixture, feature_fixture, video_file_fixture):
-    feature = FeaturesService.createFeatureAsset(projects_fixture.id,
+    feature = FeaturesService.createFeatureAsset(db_session,
+                                                 projects_fixture.id,
                                                  feature_fixture.id,
                                                  FileStorage(video_file_fixture))
     assert feature.id == feature_fixture.id
@@ -108,17 +109,19 @@ def test_create_feature_video_asset(projects_fixture, feature_fixture, video_fil
 
 
 def test_remove_feature_video_asset(projects_fixture, feature_fixture, video_file_fixture):
-    feature = FeaturesService.createFeatureAsset(projects_fixture.id,
+    feature = FeaturesService.createFeatureAsset(db_session,
+                                                 projects_fixture.id,
                                                  feature_fixture.id,
                                                  FileStorage(video_file_fixture))
-    FeaturesService.delete(feature.id)
+    FeaturesService.delete(db_session, feature.id)
     assert db_session.query(Feature).count() == 0
     assert db_session.query(FeatureAsset).count() == 0
     assert len(os.listdir(get_project_asset_dir(feature.project_id))) == 0
 
 
 def test_create_feature_shpfile(projects_fixture, shapefile_fixture, shapefile_additional_files_fixture):
-    features = FeaturesService.fromShapefile(projects_fixture.id,
+    features = FeaturesService.fromShapefile(db_session,
+                                             projects_fixture.id,
                                              shapefile_fixture,
                                              metadata={},
                                              additional_files=shapefile_additional_files_fixture,
@@ -136,7 +139,7 @@ def test_create_tile_server(projects_fixture):
         "attribution": "contributors"
     }
 
-    tile_server = FeaturesService.addTileServer(projectId=projects_fixture.id, data=data)
+    tile_server = FeaturesService.addTileServer(database_session=db_session, projectId=projects_fixture.id, data=data)
     assert tile_server.name == "Test"
     assert tile_server.type == "tms"
     assert tile_server.url == "www.test.com"
@@ -151,8 +154,8 @@ def test_remove_tile_server(projects_fixture):
         "attribution": "contributors"
     }
 
-    tile_server = FeaturesService.addTileServer(projectId=projects_fixture.id, data=data)
-    FeaturesService.deleteTileServer(tile_server.id)
+    tile_server = FeaturesService.addTileServer(database_session=db_session, projectId=projects_fixture.id, data=data)
+    FeaturesService.deleteTileServer(db_session, tile_server.id)
 
     assert db_session.query(TileServer).count() == 0
 
@@ -165,13 +168,14 @@ def test_update_tile_server(projects_fixture):
         "attribution": "contributors"
     }
 
-    FeaturesService.addTileServer(projectId=projects_fixture.id, data=data)
+    FeaturesService.addTileServer(database_session=db_session, projectId=projects_fixture.id, data=data)
 
     updated_data = {
         "name": "NewTestName",
     }
 
-    updated_tile_server = FeaturesService.updateTileServer(tileServerId=1,
+    updated_tile_server = FeaturesService.updateTileServer(database_session=db_session,
+                                                           tileServerId=1,
                                                            data=updated_data)
     assert updated_tile_server.name == "NewTestName"
 
@@ -184,20 +188,21 @@ def test_update_tile_servers(projects_fixture):
         "attribution": "contributors"
     }
 
-    resp1 = FeaturesService.addTileServer(projectId=projects_fixture.id, data=data)
-    resp2 = FeaturesService.addTileServer(projectId=projects_fixture.id, data=data)
+    resp1 = FeaturesService.addTileServer(db_session, projectId=projects_fixture.id, data=data)
+    resp2 = FeaturesService.addTileServer(db_session, projectId=projects_fixture.id, data=data)
 
     updated_data = [{"id": resp1.id, "name": "NewTestName1"},
                     {"id": resp2.id, "name": "NewTestName2"}]
 
-    updated_tile_server_list = FeaturesService.updateTileServers(dataList=updated_data)
+    updated_tile_server_list = FeaturesService.updateTileServers(database_session=db_session, dataList=updated_data)
 
     assert updated_tile_server_list[0].name == "NewTestName1"
     assert updated_tile_server_list[1].name == "NewTestName2"
 
 
 def test_create_tile_server_from_file(projects_fixture, tile_server_ini_file_fixture):
-    tile_server = FeaturesService.fromINI(projects_fixture.id,
+    tile_server = FeaturesService.fromINI(db_session,
+                                          projects_fixture.id,
                                           tile_server_ini_file_fixture,
                                           metadata={})
 
@@ -208,7 +213,7 @@ def test_create_tile_server_from_file(projects_fixture, tile_server_ini_file_fix
 
 
 def test_create_questionnaire_feature(projects_fixture, questionnaire_file_fixture):
-    feature = FeaturesService.fromRAPP(projects_fixture.id, questionnaire_file_fixture, metadata={})
+    feature = FeaturesService.fromRAPP(db_session, projects_fixture.id, questionnaire_file_fixture, metadata={})
     assert feature.project_id == projects_fixture.id
     assert len(feature.assets) == 1
     assert db_session.query(Feature).count() == 1

--- a/geoapi/tests/api_tests/test_notifications_routes.py
+++ b/geoapi/tests/api_tests/test_notifications_routes.py
@@ -11,16 +11,16 @@ test_uuid2 = uuid.uuid4()
 @pytest.fixture
 def notifications(userdata):
     u1 = db_session.query(User).filter(User.username == "test1").first()
-    NotificationsService.create(u1, "error", "test error")
-    NotificationsService.create(u1, "success", "test success")
+    NotificationsService.create(db_session, u1, "error", "test error")
+    NotificationsService.create(db_session, u1, "success", "test success")
 
 
 @pytest.fixture
 def progress_notifications(userdata):
     u1 = db_session.query(User).filter(User.username == "test1").first()
     u2 = db_session.query(User).filter(User.username == "test2").first()
-    error = NotificationsService.createProgress(u1, "error", "test error", test_uuid1)
-    success = NotificationsService.createProgress(u2, "success", "test success", test_uuid2)
+    error = NotificationsService.createProgress(db_session, u1, "error", "test error", test_uuid1)
+    success = NotificationsService.createProgress(db_session, u2, "success", "test success", test_uuid2)
     yield [error, success]
 
 

--- a/geoapi/tests/api_tests/test_point_cloud_routes.py
+++ b/geoapi/tests/api_tests/test_point_cloud_routes.py
@@ -52,33 +52,6 @@ def test_delete_point_cloud(test_client, projects_fixture, point_cloud_fixture):
     assert point_cloud is None
 
 
-def test_upload_lidar(test_client, projects_fixture, point_cloud_fixture, lidar_las1pt2_file_fixture,
-                      check_point_cloud_mock, get_point_cloud_info_mock, convert_to_potree_mock):
-    u1 = db_session.query(User).get(1)
-    resp = test_client.post(
-        '/projects/1/point-cloud/1/',
-        data={"file": lidar_las1pt2_file_fixture},
-        headers={'x-jwt-assertion-test': u1.jwt}
-    )
-    assert resp.status_code == 200
-    convert_to_potree_mock.apply_async.assert_called_once()
-
-
-def test_upload_lidar_missing_crs(test_client,
-                                  projects_fixture,
-                                  point_cloud_fixture,
-                                  empty_las_file_fixture,
-                                  check_point_cloud_mock_missing_crs):
-    u1 = db_session.query(User).get(1)
-    resp = test_client.post(
-        '/projects/1/point-cloud/1/',
-        data={"file": empty_las_file_fixture},
-        headers={'x-jwt-assertion-test': u1.jwt}
-    )
-    assert resp.status_code == 400
-    assert "coordinate reference system could not be found" in resp.json['message']
-
-
 @patch("geoapi.tasks.external_data.import_point_clouds_from_agave")
 def test_import_lidar_tapis(import_point_clouds_from_agave_mock,
                             test_client,

--- a/geoapi/tests/api_tests/test_point_cloud_service.py
+++ b/geoapi/tests/api_tests/test_point_cloud_service.py
@@ -1,13 +1,14 @@
 import pytest
 import os
+from unittest.mock import patch
 
 from geoapi.db import db_session
 from geoapi.services.point_cloud import PointCloudService
 from geoapi.services.features import FeaturesService
 from geoapi.models import User, Feature, FeatureAsset, PointCloud
-from geoapi.tasks.lidar import convert_to_potree
 from geoapi.utils.assets import get_project_asset_dir, get_asset_path
 from geoapi.celery_app import app
+from geoapi.tasks.external_data import import_point_clouds_from_agave
 
 POINT_CLOUD_DATA = {'description': "description", 'conversion_parameters': "--scale 2.0"}
 
@@ -22,7 +23,8 @@ def celery_task_always_eager():
 def test_add_point_cloud(projects_fixture):
     u1 = db_session.query(User).get(1)
 
-    point_cloud = PointCloudService.create(projectId=projects_fixture.id,
+    point_cloud = PointCloudService.create(database_session=db_session,
+                                           projectId=projects_fixture.id,
                                            data=POINT_CLOUD_DATA,
                                            user=u1)
     assert point_cloud.description == "description"
@@ -32,66 +34,37 @@ def test_add_point_cloud(projects_fixture):
     assert db_session.query(PointCloud).count() == 1
 
 
-@pytest.mark.worker
-def test_add_point_cloud_file(projects_fixture, point_cloud_fixture,
-                              lidar_las1pt2_file_fixture, convert_to_potree_mock, check_point_cloud_mock,
-                              get_point_cloud_info_mock):
-
-    filename = os.path.basename(lidar_las1pt2_file_fixture.name)
-    task = PointCloudService.fromFileObj(point_cloud_fixture.id, lidar_las1pt2_file_fixture, filename)
-
-    assert task.status == "RUNNING"
-    assert point_cloud_fixture.task_id == task.id
-    # load updated point cloud
-    point_cloud = db_session.query(PointCloud).get(1)
-    las_files = os.listdir(get_asset_path(point_cloud.path, PointCloudService.ORIGINAL_FILES_DIR))
-    assert len(las_files) == 1
-    assert las_files[0] == os.path.basename(filename)
-    original_file_size = os.fstat(lidar_las1pt2_file_fixture.fileno()).st_size
-    asset_file_path = os.path.join(get_asset_path(point_cloud.path, PointCloudService.ORIGINAL_FILES_DIR), filename)
-    assert os.path.getsize(asset_file_path) == original_file_size
-
-    # run conversion tool (that we had mocked)
-    _, convert_kwargs = convert_to_potree_mock.apply_async.call_args
-    assert projects_fixture.id == convert_kwargs['args'][0]
-    convert_to_potree(projects_fixture.id)
-
-    # load updated point cloud
-    point_cloud = db_session.query(PointCloud).get(1)
-
-    assert point_cloud.task.status == "FINISHED"
-    assert db_session.query(Feature).count() == 1
-    assert db_session.query(FeatureAsset).count() == 1
-    assert len(os.listdir(get_project_asset_dir(point_cloud.project_id))) == 2
-    assert len(os.listdir(
-        get_asset_path(point_cloud.feature.assets[0].path))) == 5  # index.html, preview.html, pointclouds, libs, logo
-    assert os.path.isfile(os.path.join(get_asset_path(point_cloud.feature.assets[0].path), "preview.html"))
-    with open(os.path.join(get_asset_path(point_cloud.feature.assets[0].path), "preview.html"), 'r+') as f:
-        preview = f.read()
-        assert "nsf_logo" not in preview
-        assert "$('.potree_menu_toggle').hide()" in preview
-
-
 def test_delete_point_cloud(projects_fixture):
     u1 = db_session.query(User).get(1)
 
-    point_cloud = PointCloudService.create(projectId=projects_fixture.id,
+    point_cloud = PointCloudService.create(database_session=db_session,
+                                           projectId=projects_fixture.id,
                                            data=POINT_CLOUD_DATA,
                                            user=u1)
-    PointCloudService.delete(pointCloudId=point_cloud.id)
+    PointCloudService.delete(database_session=db_session, pointCloudId=point_cloud.id)
     assert db_session.query(PointCloud).count() == 0
     assert db_session.query(Feature).count() == 0
     assert len(os.listdir(get_project_asset_dir(point_cloud.project_id))) == 0
 
 
 @pytest.mark.worker
-def test_delete_point_cloud_feature(celery_task_always_eager, projects_fixture, point_cloud_fixture,
+@patch("geoapi.tasks.external_data.AgaveUtils")
+def test_delete_point_cloud_feature(MockAgaveUtils, celery_task_always_eager, projects_fixture, point_cloud_fixture,
                                     lidar_las1pt2_file_fixture):
-    PointCloudService.fromFileObj(point_cloud_fixture.id, lidar_las1pt2_file_fixture, lidar_las1pt2_file_fixture.name)
+    # create a point cloud feature so we can delete it
+    MockAgaveUtils().getFile.return_value = lidar_las1pt2_file_fixture
+    u1 = db_session.query(User).get(1)
+    files = [{"system": "designsafe.storage.default", "path": "file1.las"}]
+    import_point_clouds_from_agave(u1.id, files, point_cloud_fixture.id)
+
+    db_session.refresh(point_cloud_fixture)
+
     point_cloud = db_session.query(PointCloud).get(1)
     feature_asset_path = get_asset_path(point_cloud.feature.assets[0].path)
 
-    FeaturesService.delete(point_cloud.feature.id)
+    # delete point cloud feature
+    FeaturesService.delete(db_session, point_cloud.feature.id)
+
     assert db_session.query(PointCloud).count() == 1
     assert db_session.query(PointCloud).get(1).feature is None
     assert db_session.query(Feature).count() == 0
@@ -102,7 +75,7 @@ def test_delete_point_cloud_feature(celery_task_always_eager, projects_fixture, 
 
 def test_update_point_cloud(projects_fixture, point_cloud_fixture, convert_to_potree_mock):
     data = {'description': "new description", 'conversion_parameters': "--scale 5.0"}
-    point_cloud = PointCloudService.update(point_cloud_fixture.id, data=data)
+    point_cloud = PointCloudService.update(db_session, point_cloud_fixture.id, data=data)
     convert_to_potree_mock.apply_async.assert_called_once()
     assert point_cloud.description == "new description"
     assert point_cloud.conversion_parameters == "--scale 5.0"
@@ -111,6 +84,6 @@ def test_update_point_cloud(projects_fixture, point_cloud_fixture, convert_to_po
 def test_update_point_cloud_without_changing_conversion_parameters(projects_fixture, point_cloud_fixture,
                                                                    convert_to_potree_mock):
     data = {'description': "new description"}
-    point_cloud = PointCloudService.update(point_cloud_fixture.id, data=data)
+    point_cloud = PointCloudService.update(db_session, point_cloud_fixture.id, data=data)
     convert_to_potree_mock.apply_async.assert_not_called()
     assert point_cloud.description == "new description"

--- a/geoapi/tests/api_tests/test_projects_service.py
+++ b/geoapi/tests/api_tests/test_projects_service.py
@@ -16,7 +16,7 @@ def test_create_project():
             'description': "test description",
         },
     }
-    proj = ProjectsService.create(data, user)
+    proj = ProjectsService.create(db_session, data, user)
     assert proj.id is not None
     assert len(proj.users) == 1
     assert proj.name == "test name"
@@ -25,7 +25,7 @@ def test_create_project():
 
 
 def test_delete_project(projects_fixture, remove_project_assets_mock, user1):
-    ProjectsService.delete(user1, projects_fixture.id)
+    ProjectsService.delete(db_session, user1, projects_fixture.id)
     projects = db_session.query(Project).all()
     assert projects == []
 
@@ -47,7 +47,7 @@ def test_create_observable_project(userdata,
         'watch_content': True
     }
 
-    proj = ProjectsService.create(data, user)
+    proj = ProjectsService.create(db_session, data, user)
     assert len(proj.users) == 2
 
 
@@ -69,41 +69,41 @@ def test_create_observable_project_already_exists(observable_projects_fixture,
     }
 
     with pytest.raises(ObservableProjectAlreadyExists):
-        ProjectsService.create(data, user)
+        ProjectsService.create(db_session, data, user)
 
 
 def test_get_with_project_id(projects_fixture):
-    project = ProjectsService.get(project_id=projects_fixture.id)
+    project = ProjectsService.get(database_session=db_session, project_id=projects_fixture.id)
     assert project.id == projects_fixture.id
 
 
 def test_get_with_uid(projects_fixture):
-    project = ProjectsService.get(uuid=projects_fixture.uuid)
+    project = ProjectsService.get(database_session=db_session, uuid=projects_fixture.uuid)
     assert project.uuid == projects_fixture.uuid
 
 
 def test_get_missing_argument(projects_fixture):
     with pytest.raises(ValueError):
-        ProjectsService.get()
+        ProjectsService.get(db_session)
 
 
 def test_get_features(projects_fixture, feature_fixture):
-    project_features = ProjectsService.getFeatures(projects_fixture.id)
+    project_features = ProjectsService.getFeatures(db_session, projects_fixture.id)
     assert len(project_features['features']) == 1
 
 
 def test_get_features_filter_type(projects_fixture,
                                   feature_fixture,
                                   image_feature_fixture):
-    project_features = ProjectsService.getFeatures(projects_fixture.id)
+    project_features = ProjectsService.getFeatures(db_session, projects_fixture.id)
     assert len(project_features['features']) == 2
 
     query = {'assetType': 'image'}
-    project_features = ProjectsService.getFeatures(projects_fixture.id, query)
+    project_features = ProjectsService.getFeatures(db_session, projects_fixture.id, query)
     assert len(project_features['features']) == 1
 
     query = {'assetType': 'video'}
-    project_features = ProjectsService.getFeatures(projects_fixture.id, query)
+    project_features = ProjectsService.getFeatures(db_session, projects_fixture.id, query)
     assert len(project_features['features']) == 0
 
 
@@ -115,6 +115,6 @@ def test_update_project(projects_fixture):
             'description': 'new description',
         },
     }
-    proj = ProjectsService.update(user, projects_fixture.id, data)
+    proj = ProjectsService.update(db_session, user, projects_fixture.id, data)
     assert proj.name == "new name"
     assert proj.description == "new description"

--- a/geoapi/tests/api_tests/test_streetview_service.py
+++ b/geoapi/tests/api_tests/test_streetview_service.py
@@ -9,7 +9,7 @@ from geoapi.models import User
 @pytest.mark.skip(reason="Update needed; https://jira.tacc.utexas.edu/browse/DES-2264")
 def test_create_streetview_token():
     user = db_session.query(User).get(1)
-    StreetviewService.setToken(user, 'mapillary', 'test token')
+    StreetviewService.setToken(db_session, user, 'mapillary', 'test token')
     assert user.mapillary_jwt == 'test token'
 
 
@@ -17,14 +17,14 @@ def test_create_streetview_token():
 def test_get_streetview_token():
     user = db_session.query(User).get(1)
     StreetviewService.setToken(user, 'mapillary', 'test token')
-    tok = StreetviewService.getToken(user, 'mapillary')
+    tok = StreetviewService.getToken(db_session, user, 'mapillary')
     assert user.mapillary_jwt == tok
 
 
 @pytest.mark.skip(reason="Update needed; https://jira.tacc.utexas.edu/browse/DES-2264")
 def test_create_streetview():
     user = db_session.query(User).get(1)
-    streetview = StreetviewService.create(user.id, 'test system', 'test path')
+    streetview = StreetviewService.create(db_session, user.id, 'test system', 'test path')
     assert streetview.id is not None
 
 
@@ -33,7 +33,7 @@ def test_get_user_streetview():
     user = db_session.query(User).get(1)
     StreetviewService.create(user.id, 'test system', 'test path')
     StreetviewService.create(user.id, 'test system 2', 'test path 2')
-    streetview_list = StreetviewService.getAll(user)
+    streetview_list = StreetviewService.getAll(db_session, user)
     assert len(streetview_list) == 2
 
 
@@ -52,7 +52,7 @@ def test_get_streetview_system_path():
 def test_create_sequence():
     user = db_session.query(User).get(1)
     streetview = StreetviewService.create(user.id, 'test system', 'test path')
-    sequence = StreetviewService.createSequence(streetview_id=streetview.id)
+    sequence = StreetviewService.createSequence(database_session=db_session, streetview_id=streetview.id)
     assert len(streetview.sequences) == 1
     assert sequence.streetview_id == 1
 
@@ -61,7 +61,7 @@ def test_create_sequence():
 def test_update_sequence():
     user = db_session.query(User).get(1)
     streetview = StreetviewService.create(user.id, 'test system', 'test path')
-    sequence = StreetviewService.createSequence(streetview.id, service='service', sequence_key='test sequence key')
+    sequence = StreetviewService.createSequence(db_session, streetview.id, service='service', sequence_key='test sequence key')
     data = {
         'sequence_key': 'new sequence key',
     }
@@ -73,7 +73,7 @@ def test_update_sequence():
 @pytest.mark.skip(reason="Update needed; https://jira.tacc.utexas.edu/browse/DES-2264")
 def test_add_sequence_to_path():
     user = db_session.query(User).get(1)
-    streetview = StreetviewService.create(user.id, 'test system', 'test path')
+    streetview = StreetviewService.create(db_session, user.id, 'test system', 'test path')
     data = {
         'dir': {
             'path': 'test path',
@@ -84,5 +84,5 @@ def test_add_sequence_to_path():
         'service': 'mapillary',
         'organizationId': '12345678'
     }
-    StreetviewService.addSequenceToStreetview(user, data)
+    StreetviewService.addSequenceToStreetview(db_session, user, data)
     assert len(streetview.sequences) == 4

--- a/geoapi/tests/api_tests/test_tile_server_routes.py
+++ b/geoapi/tests/api_tests/test_tile_server_routes.py
@@ -21,7 +21,6 @@ def test_add_tile_server(test_client, projects_fixture):
                             json=_get_tile_server_data(),
                             headers={'x-jwt-assertion-test': u1.jwt})
     data = resp.get_json()
-    resp.status_code
     assert resp.status_code == 200
     assert data["name"] == "Test"
     assert data["type"] == "tms"

--- a/geoapi/tests/api_tests/test_users_service.py
+++ b/geoapi/tests/api_tests/test_users_service.py
@@ -7,13 +7,13 @@ import pytest
 
 
 def test_user_get(userdata):
-    user = UserService.getUser("test1", "test")
+    user = UserService.getUser(db_session, "test1", "test")
     assert user.id is not None
     assert user.created is not None
 
 
 def test_user_create(userdata):
-    user = UserService.create(username="newUser", jwt="testjwt", tenant="test")
+    user = UserService.create(database_session=db_session, username="newUser", jwt="testjwt", tenant="test")
     assert user.id is not None
     assert user.created is not None
     assert user.username == 'newUser'
@@ -21,83 +21,83 @@ def test_user_create(userdata):
 
 
 def test_projects_for_user(userdata):
-    user = UserService.getUser("test1", "test")
+    user = UserService.getUser(db_session, "test1", "test")
     data = {
         'project': {
             'name': 'new project',
             'description': 'test'
         },
     }
-    ProjectsService.create(data, user)
-    myProjects = ProjectsService.list(user)
-    assert len(myProjects) == 1
-    assert myProjects[0].name == 'new project'
+    ProjectsService.create(db_session, data, user)
+    my_projects = ProjectsService.list(db_session, user)
+    assert len(my_projects) == 1
+    assert my_projects[0].name == 'new project'
 
 
 def test_add_new_user_to_project(userdata):
-    user = UserService.getUser("test1", "test")
+    user = UserService.getUser(db_session, "test1", "test")
     data = {
         'project': {
             'name': 'new project',
             'description': 'test'
         },
     }
-    proj = ProjectsService.create(data, user)
-    ProjectsService.addUserToProject(proj.id, "newUser", admin=False)
-    proj = ProjectsService.get(project_id=proj.id)
+    proj = ProjectsService.create(db_session, data, user)
+    ProjectsService.addUserToProject(db_session, proj.id, "newUser", admin=False)
+    proj = ProjectsService.get(database_session=db_session, project_id=proj.id)
     assert len(proj.users) == 2
 
 
 def test_add_existing_user_to_project(user1, user2, projects_fixture):
-    assert not UserService.canAccess(user2, projects_fixture.id)
+    assert not UserService.canAccess(db_session, user2, projects_fixture.id)
 
-    ProjectsService.addUserToProject(projectId=projects_fixture.id, username=user2.username, admin=False)
-    assert UserService.canAccess(user2, projects_fixture.id)
+    ProjectsService.addUserToProject(database_session=db_session, projectId=projects_fixture.id, username=user2.username, admin=False)
+    assert UserService.canAccess(db_session, user2, projects_fixture.id)
     project_user = db_session.query(ProjectUser).filter(ProjectUser.project_id == projects_fixture.id) \
         .filter(ProjectUser.user_id == user2.id).one_or_none()
     assert project_user.admin is False
-    assert UserService.canAccess(user1, projects_fixture.id)
+    assert UserService.canAccess(db_session, user1, projects_fixture.id)
 
 
 def test_add_existing_user_to_project_as_admin(user1, user2, projects_fixture):
-    assert not UserService.canAccess(user2, projects_fixture.id)
+    assert not UserService.canAccess(db_session, user2, projects_fixture.id)
 
-    ProjectsService.addUserToProject(projectId=projects_fixture.id, username=user2.username, admin=True)
-    assert UserService.canAccess(user2, projects_fixture.id)
+    ProjectsService.addUserToProject(database_session=db_session, projectId=projects_fixture.id, username=user2.username, admin=True)
+    assert UserService.canAccess(db_session, user2, projects_fixture.id)
     project_user = db_session.query(ProjectUser).filter(ProjectUser.project_id == projects_fixture.id) \
         .filter(ProjectUser.user_id == user2.id).one_or_none()
     assert project_user.admin is True
-    assert UserService.canAccess(user1, projects_fixture.id)
+    assert UserService.canAccess(db_session, user1, projects_fixture.id)
 
 
 def test_remove_user(projects_fixture):
-    ProjectsService.addUserToProject(projects_fixture.id, "newUser", admin=False)
+    ProjectsService.addUserToProject(db_session, projects_fixture.id, "newUser", admin=False)
     assert len(projects_fixture.users) == 2
-    ProjectsService.removeUserFromProject(projects_fixture.id, "newUser")
+    ProjectsService.removeUserFromProject(db_session, projects_fixture.id, "newUser")
     assert len(projects_fixture.users) == 1
 
 
 def test_remove_missing_user_failure(projects_fixture):
-    ProjectsService.addUserToProject(projects_fixture.id, "newUser", admin=False)
+    ProjectsService.addUserToProject(db_session, projects_fixture.id, "newUser", admin=False)
     assert len(projects_fixture.users) == 2
     with pytest.raises(ApiException):
-        ProjectsService.removeUserFromProject(projects_fixture.id,
+        ProjectsService.removeUserFromProject(db_session, projects_fixture.id,
                                               "someOtherUser")
     assert len(projects_fixture.users) == 2
 
 
 def test_remove_user_with_only_one_user_failure(projects_fixture):
     with pytest.raises(ApiException):
-        ProjectsService.removeUserFromProject(projects_fixture.id, "test1")
+        ProjectsService.removeUserFromProject(db_session, projects_fixture.id, "test1")
     assert len(projects_fixture.users) == 1
 
 
 def test_remove_user_from_observable_project(observable_projects_fixture):
     project = observable_projects_fixture.project
 
-    ProjectsService.addUserToProject(project.id, "newUser", admin=False)
+    ProjectsService.addUserToProject(db_session, project.id, "newUser", admin=False)
     assert len(project.users) == 2
-    ProjectsService.removeUserFromProject(project.id, "newUser")
+    ProjectsService.removeUserFromProject(db_session, project.id, "newUser")
     assert len(project.users) == 1
 
 
@@ -105,9 +105,10 @@ def test_remove_last_user_with_jwt_from_observable_project_failure(
         observable_projects_fixture):
     project = observable_projects_fixture.project
 
-    ProjectsService.addUserToProject(project.id, "newUser", admin=False)
+    ProjectsService.addUserToProject(db_session, project.id, "newUser", admin=False)
     assert len(project.users) == 2
     with pytest.raises(ApiException):
-        ProjectsService.removeUserFromProject(project.id,
+        ProjectsService.removeUserFromProject(db_session,
+                                              project.id,
                                               project.users[0].username)
     assert len(project.users) == 2

--- a/geoapi/tests/conftest.py
+++ b/geoapi/tests/conftest.py
@@ -7,7 +7,7 @@ from unittest.mock import patch, MagicMock
 from werkzeug.datastructures import FileStorage
 import laspy
 
-from geoapi.db import Base, db_session, engine
+from geoapi.db import Base, engine, db_session
 from geoapi.models.users import User
 from geoapi.models.project import Project, ProjectUser
 from geoapi.models.observable_data import ObservableDataProject
@@ -63,7 +63,7 @@ def user2(userdata):
 
 @pytest.fixture(scope="function")
 def projects_fixture():
-    """ Project with 1 users and test1 is an admin"""
+    """ Project with 1 user and test1 is an admin"""
     proj = Project(name="test", description="description")
     u1 = db_session.query(User).filter(User.username == "test1").first()
     proj.users.append(u1)
@@ -139,7 +139,7 @@ def observable_projects_fixture():
 def point_cloud_fixture():
     u1 = db_session.query(User).filter(User.username == "test1").first()
     data = {"description": "description"}
-    point_cloud = PointCloudService.create(projectId=1, data=data, user=u1)
+    point_cloud = PointCloudService.create(db_session, projectId=1, data=data, user=u1)
     yield point_cloud
 
 
@@ -357,7 +357,7 @@ def feature_fixture(projects_fixture):
 
 @pytest.fixture(scope="function")
 def image_feature_fixture(image_file_fixture):
-    yield FeaturesService.fromImage(1, image_file_fixture, metadata={})
+    yield FeaturesService.fromImage(db_session, 1, image_file_fixture, metadata={})
 
 
 @pytest.fixture(scope="function")
@@ -385,19 +385,14 @@ def convert_to_potree_mock():
 @pytest.fixture(scope="function")
 def check_point_cloud_mock():
     with patch('geoapi.services.point_cloud.check_point_cloud') as mock_check_point_cloud_mock:
-        class FakeAsyncResult:
-            def get(self):
-                return None
-        mock_check_point_cloud_mock.apply_async.return_value = FakeAsyncResult()
+        mock_check_point_cloud_mock.return_value = None
         yield mock_check_point_cloud_mock
 
 
 @pytest.fixture(scope="function")
 def check_point_cloud_mock_missing_crs():
     with patch('geoapi.services.point_cloud.check_point_cloud') as mock_check_point_cloud_mock:
-        mock_result = MagicMock()
-        mock_result.get.side_effect = InvalidCoordinateReferenceSystem()
-        mock_check_point_cloud_mock.apply_async.return_value = mock_result
+        mock_check_point_cloud_mock.side_effect = InvalidCoordinateReferenceSystem()
         yield mock_check_point_cloud_mock
 
 
@@ -407,7 +402,7 @@ def get_point_cloud_info_mock():
         mock_result = MagicMock()
         mock_result.get.return_value = [{'name': 'test.las'}]
 
-        mock_get_point_cloud_info.apply_async.return_value = mock_result
+        mock_get_point_cloud_info.return_value = mock_result
         yield mock_get_point_cloud_info
 
 

--- a/geoapi/tests/services/test_user_service.py
+++ b/geoapi/tests/services/test_user_service.py
@@ -1,15 +1,16 @@
 from geoapi.services.users import UserService
+from geoapi.db import db_session
 
 
 def test_is_admin_or_creator(user1, user2, projects_fixture, projects_fixture2):
-    assert UserService.canAccess(user1, projects_fixture.id)
-    assert UserService.is_admin_or_creator(user1, projects_fixture.id)
-    assert not UserService.canAccess(user2, projects_fixture.id)
-    assert not UserService.is_admin_or_creator(user2, projects_fixture.id)
+    assert UserService.canAccess(db_session, user1, projects_fixture.id)
+    assert UserService.is_admin_or_creator(db_session, user1, projects_fixture.id)
+    assert not UserService.canAccess(db_session, user2, projects_fixture.id)
+    assert not UserService.is_admin_or_creator(db_session, user2, projects_fixture.id)
 
 
 def test_is_admin_or_creator2(user1, user2, projects_fixture, projects_fixture2):
-    assert UserService.canAccess(user1, projects_fixture2.id)
-    assert UserService.is_admin_or_creator(user1, projects_fixture2.id)
-    assert UserService.canAccess(user2, projects_fixture2.id)
-    assert not UserService.is_admin_or_creator(user2, projects_fixture2.id)
+    assert UserService.canAccess(db_session, user1, projects_fixture2.id)
+    assert UserService.is_admin_or_creator(db_session, user1, projects_fixture2.id)
+    assert UserService.canAccess(db_session, user2, projects_fixture2.id)
+    assert not UserService.is_admin_or_creator(db_session, user2, projects_fixture2.id)

--- a/geoapi/tests/tasks_tests/test_streetview.py
+++ b/geoapi/tests/tasks_tests/test_streetview.py
@@ -1,6 +1,7 @@
 from geoapi.tasks.streetview import _from_tapis
 from geoapi.utils.agave import AgaveFileListing
 from geoapi.utils.streetview import (get_project_streetview_dir, remove_project_streetview_dir)
+from geoapi.db import db_session
 from unittest.mock import patch, MagicMock
 import os
 import pytest
@@ -49,7 +50,7 @@ def test_get_file_to_path(user1, task_fixture, mock_notifications_service, agave
     path = "path/"
     task_uuid = uuid.uuid3(uuid.NAMESPACE_URL, system_id + path)
 
-    _from_tapis(user1, task_uuid, system_id, path)
+    _from_tapis(db_session, user1, task_uuid, system_id, path)
 
     assert len(os.listdir(get_project_streetview_dir(user1.id, task_uuid))) == 1
     remove_project_streetview_dir(user1.id, task_uuid)

--- a/kube/Makefile
+++ b/kube/Makefile
@@ -32,8 +32,8 @@ create: checkforcontext checkfortag
 .PHONY: delete
 delete: checkforcontext
 	@echo "Deleting geoapi deployment/services/migration-job in '$(KUBE_CONTEXT)' context"
-	kubectl delete --context $(KUBE_CONTEXT) --ignore-not-found=true  deployment geoapi geoapi-workers geoapi-celerybeat geoapi-nginx geoapi-postgres geoapi-rabbitmq
-	kubectl delete --context $(KUBE_CONTEXT) --ignore-not-found=true service geoapi geoapi-nginx geoapi-postgres geoapi-rabbitmq
+	kubectl delete --context $(KUBE_CONTEXT) --ignore-not-found=true  deployment geoapi geoapi-workers geoapi-celerybeat geoapi-nginx geoapi-rabbitmq
+	kubectl delete --context $(KUBE_CONTEXT) --ignore-not-found=true service geoapi geoapi-nginx geoapi-rabbitmq
 	kubectl delete --context $(KUBE_CONTEXT) --ignore-not-found=true job/geoapi-migrations
 
 .PHONY: delete-staging

--- a/kube/geoapi.yaml
+++ b/kube/geoapi.yaml
@@ -95,22 +95,6 @@ metadata:
     kompose.cmd: kompose convert
     kompose.version: 1.16.0 (0c01309)
   labels:
-    app: geoapi-postgres
-  name: geoapi-postgres
-spec:
-  ports:
-  - port: 5432
-    targetPort: 5432
-  selector:
-    app: geoapi-postgres
----
-apiVersion: v1
-kind: Service
-metadata:
-  annotations:
-    kompose.cmd: kompose convert
-    kompose.version: 1.16.0 (0c01309)
-  labels:
     app: geoapi-nginx
   name: geoapi-nginx
 spec:

--- a/kube/geoapi.yaml
+++ b/kube/geoapi.yaml
@@ -244,8 +244,6 @@ spec:
           - configMapRef:
               name: geoapi-environment-vars
         env:
-          - name: APP_CONTEXT
-            value: "celery"
           - name: RABBITMQ_PASSWD
             valueFrom:
               secretKeyRef:

--- a/kube/geoapi.yaml
+++ b/kube/geoapi.yaml
@@ -244,6 +244,8 @@ spec:
           - configMapRef:
               name: geoapi-environment-vars
         env:
+          - name: APP_CONTEXT
+            value: "celery"
           - name: RABBITMQ_PASSWD
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
## Overview: ##

~Disable pool connections for celery workers. This is a temp fix/workaround for our connection related issues.~

This PR refactors how database session is used in celery worker tasks.  Now, `create_task_session` is a context manger that provides a session and then ensure that session is closed after its used (and rolled-back if there was an exception).

Tasks look like the following:
```
@app.task()
def some_task():
    """
    Refresh all observable projects
    """
    with create_task_session() as session:
        # use the session
         point_cloud = PointCloudService.get(session, pointCloudId)

    # `session.close` is called by the context manager
    # if there is an unhandled exception then a`session.rollback()` is also performed.
```

So going forward,`db_session` from db.py is a scoped_session that is used when processing requests in Flask and also in unit tests for fixtures and asserts.  Then for all celery tasks, the  `create_task_session` is used.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-141](https://jira.tacc.utexas.edu/browse/WG-141)
