### PR TITLE
Task/WG-156 improve session handling in long running tasks

### DIFF
--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -154,9 +154,7 @@ def import_point_clouds_from_agave(userId: int, files, pointCloudId: int):
         point_cloud.task = task
         session.add(point_cloud)
         session.add(task)
-        logger.error("committing")
         session.commit()
-        logger.error("done committing")
 
         new_asset_files = []
         failed_message = None

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -230,6 +230,7 @@ def import_point_clouds_from_agave(userId: int, files, pointCloudId: int):
             _update_point_cloud_task(session, pointCloudId, description="", status="FAILED")
             NotificationsService.create(session, user, "error", "Processing failed for point cloud ({})!".format(pointCloudId))
 
+
 @app.task(rate_limit="5/s")
 def import_from_agave(tenant_id: str, userId: int, systemId: str, path: str, projectId: int):
     """

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -218,6 +218,7 @@ def import_point_clouds_from_agave(userId: int, files, pointCloudId: int):
         convert_to_potree(pointCloudId)
         with create_task_session() as database_session:
             user = session.query(User).get(userId)
+            logger.info(f"point cloud:{pointCloudId} conversion completed for user:{user.username} and files:{files}")
             NotificationsService.create(database_session,
                                         user,
                                         "success",
@@ -225,7 +226,7 @@ def import_point_clouds_from_agave(userId: int, files, pointCloudId: int):
     except:  # noqa: E722
         with create_task_session() as database_session:
             user = session.query(User).get(userId)
-            logger.exception("point cloud:{} conversion failed for user:{}".format(pointCloudId, user.username))
+            logger.exception(f"point cloud:{pointCloudId} conversion failed for user:{user.username} and files:{files}")
             _update_point_cloud_task(database_session, pointCloudId, description="", status="FAILED")
             NotificationsService.create(database_session, user, "error", "Processing failed for point cloud ({})!".format(pointCloudId))
         return

--- a/geoapi/tasks/lidar.py
+++ b/geoapi/tasks/lidar.py
@@ -82,31 +82,32 @@ def convert_to_potree(self, pointCloudId: int) -> None:
 
     with create_task_session() as session:
         point_cloud = PointCloudService.get(session, pointCloudId)
-
+        conversion_parameters = point_cloud.conversion_parameters
         path_to_original_point_clouds = get_asset_path(point_cloud.path, PointCloudService.ORIGINAL_FILES_DIR)
         path_temp_processed_point_cloud_path = get_asset_path(point_cloud.path, PointCloudService.PROCESSED_DIR)
 
-        input_files = [get_asset_path(path_to_original_point_clouds, file)
-                       for file in os.listdir(path_to_original_point_clouds)
-                       if pathlib.Path(file).suffix.lstrip('.').lower() in PointCloudService.LIDAR_FILE_EXTENSIONS]
+    input_files = [get_asset_path(path_to_original_point_clouds, file)
+                   for file in os.listdir(path_to_original_point_clouds)
+                   if pathlib.Path(file).suffix.lstrip('.').lower() in PointCloudService.LIDAR_FILE_EXTENSIONS]
 
-        outline = get_bounding_box_2d(input_files)
+    outline = get_bounding_box_2d(input_files)
 
-        command = [
-            "PotreeConverter",
-            "--verbose",
-            "-i",
-            path_to_original_point_clouds,
-            "-o",
-            path_temp_processed_point_cloud_path,
-            "--overwrite",
-            "--generate-page",
-            "index"
-        ]
-        if point_cloud.conversion_parameters:
-            command.extend(point_cloud.conversion_parameters.split())
-        logger.info("Processing point cloud (#{}):  {}".format(pointCloudId, " ".join(command)))
-        subprocess.run(command, check=True, capture_output=True, text=True)
+    command = [
+        "PotreeConverter",
+        "--verbose",
+        "-i",
+        path_to_original_point_clouds,
+        "-o",
+        path_temp_processed_point_cloud_path,
+        "--overwrite",
+        "--generate-page",
+        "index"
+    ]
+    if conversion_parameters:
+        command.extend(conversion_parameters.split())
+    logger.info("Processing point cloud (#{}):  {}".format(pointCloudId, " ".join(command)))
+
+    subprocess.run(command, check=True, capture_output=True, text=True)
 
     with create_task_session() as session:
         point_cloud = PointCloudService.get(session, pointCloudId)


### PR DESCRIPTION
## Overview: ##

Use multiple db sessions when processing point clouds to fix issues where session is closed due to being open and inactive so long (due to large point cloud processing) 

## Related Jira tickets: ##

* [WG-156](https://jira.tacc.utexas.edu/browse/WG-156)

## Testing Steps: ##
1. Test with point cloud locally to ensure point cloud importing workflow still works (actual bug needs to be tested on prod/staging env)
