### PR TITLE
task/WG-178:  Add missing syslog to docker-compose

### DIFF
--- a/devops/geoapi-services/docker-compose.yml
+++ b/devops/geoapi-services/docker-compose.yml
@@ -16,6 +16,10 @@ services:
       - FLASK_APP=/app/geoapi/app.py
       - ASSETS_BASE_DIR=/assets
       - GEOAPI_TAG=ENV_GEOAPI_TAG
+    logging:
+      driver: syslog
+      options:
+        tag: geoapi_rabbitmq
 
   nginx:
     image: nginx
@@ -24,6 +28,10 @@ services:
     volumes:
       - /assets:/assets
       - ./nginx.conf:/etc/nginx/nginx.conf
+    logging:
+      driver: syslog
+      options:
+        tag: geoapi_nginx
     networks:
       - geoapi
 
@@ -42,6 +50,10 @@ services:
     tty: true
     container_name: geoapicelerybeat
     hostname: geoapicelerybeat
+    logging:
+      driver: syslog
+      options:
+        tag: geoapi_celerybeat
     command: "celery -A geoapi.celery_app beat -l info"
 
   api:
@@ -64,6 +76,10 @@ services:
     tty: true
     container_name: geoapi
     hostname: geoapi
+    logging:
+      driver: syslog
+      options:
+        tag: geoapi_api
     command: "gunicorn -w 4 -b 0.0.0.0:8000 geoapi.app:app -k gevent --reload --timeout 300"
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/devops/geoapi-workers/docker-compose.yml
+++ b/devops/geoapi-workers/docker-compose.yml
@@ -14,4 +14,8 @@ services:
     tty: true
     container_name: geoapiworkers
     hostname: geoapiworkers
+    logging:
+      driver: syslog
+      options:
+        tag: geoapi_workers
     command: "celery -A geoapi.celery_app worker -l info"


### PR DESCRIPTION
## Overview: ##

Add missing syslog to docker-compose

## Related Jira tickets: ##

* [WG-178](https://jira.tacc.utexas.edu/browse/WG-178)

## Notes

preparing to deploy to `dev` to ensure that is all that is missing.
