### PR TITLE
task/WG-170: fix scraping of questionnaire

### DIFF
--- a/geoapi/services/features.py
+++ b/geoapi/services/features.py
@@ -13,59 +13,21 @@ import fiona
 from geoalchemy2.shape import from_shape
 import geojson
 
+
 from geoapi.services.images import ImageService, ImageData
 from geoapi.services.vectors import VectorService
 from geoapi.models import Feature, FeatureAsset, Overlay, User, TileServer
 from geoapi.exceptions import InvalidGeoJSON, ApiException
 from geoapi.utils.assets import make_project_asset_dir, delete_assets, get_asset_relative_path
 from geoapi.log import logging
-from geoapi.utils import geometries
+from geoapi.utils import (geometries,
+                          features as features_util)
 from geoapi.utils.agave import AgaveUtils
 
 logger = logging.getLogger(__name__)
 
 
 class FeaturesService:
-    GEOJSON_FILE_EXTENSIONS = (
-        'json', 'geojson'
-    )
-
-    IMAGE_FILE_EXTENSIONS = (
-        'jpeg', 'jpg',
-    )
-
-    VIDEO_FILE_EXTENSIONS = (
-        'mp4', 'mov', 'mpeg4', 'webm'
-    )
-
-    AUDIO_FILE_EXTENSIONS = (
-        'mp3', 'aac'
-    )
-
-    GPX_FILE_EXTENSIONS = (
-        'gpx',
-    )
-
-    SHAPEFILE_FILE_EXTENSIONS = (
-        'shp',
-    )
-
-    RAPP_FILE_EXTENSIONS = (
-        'rq',
-    )
-
-    ALLOWED_GEOSPATIAL_FEATURE_ASSET_EXTENSIONS = IMAGE_FILE_EXTENSIONS + VIDEO_FILE_EXTENSIONS
-
-    INI_FILE_EXTENSIONS = (
-        'ini',
-    )
-
-    ALLOWED_GEOSPATIAL_EXTENSIONS = IMAGE_FILE_EXTENSIONS + GPX_FILE_EXTENSIONS + GEOJSON_FILE_EXTENSIONS\
-        + SHAPEFILE_FILE_EXTENSIONS + RAPP_FILE_EXTENSIONS
-
-    ALLOWED_EXTENSIONS = IMAGE_FILE_EXTENSIONS + VIDEO_FILE_EXTENSIONS + AUDIO_FILE_EXTENSIONS + GPX_FILE_EXTENSIONS\
-        + GEOJSON_FILE_EXTENSIONS + SHAPEFILE_FILE_EXTENSIONS + INI_FILE_EXTENSIONS + RAPP_FILE_EXTENSIONS
-
     @staticmethod
     def get(database_session, featureId: int) -> Feature:
         """
@@ -371,17 +333,17 @@ class FeaturesService:
     def fromFileObj(database_session, projectId: int, fileObj: IO,
                     metadata: Dict, original_path: str = None, additional_files=None) -> List[Feature]:
         ext = pathlib.Path(fileObj.filename).suffix.lstrip(".").lower()
-        if ext in FeaturesService.IMAGE_FILE_EXTENSIONS:
+        if ext in features_util.IMAGE_FILE_EXTENSIONS:
             return [FeaturesService.fromImage(database_session, projectId, fileObj, metadata, original_path)]
-        elif ext in FeaturesService.GPX_FILE_EXTENSIONS:
+        elif ext in features_util.GPX_FILE_EXTENSIONS:
             return [FeaturesService.fromGPX(database_session, projectId, fileObj, metadata, original_path)]
-        elif ext in FeaturesService.GEOJSON_FILE_EXTENSIONS:
+        elif ext in features_util.GEOJSON_FILE_EXTENSIONS:
             return FeaturesService.fromGeoJSON(database_session, projectId, fileObj, {}, original_path)
-        elif ext in FeaturesService.SHAPEFILE_FILE_EXTENSIONS:
+        elif ext in features_util.SHAPEFILE_FILE_EXTENSIONS:
             return FeaturesService.fromShapefile(database_session, projectId, fileObj, {}, additional_files, original_path)
-        elif ext in FeaturesService.INI_FILE_EXTENSIONS:
+        elif ext in features_util.INI_FILE_EXTENSIONS:
             return FeaturesService.fromINI(database_session, projectId, fileObj, {}, original_path)
-        elif ext in FeaturesService.RAPP_FILE_EXTENSIONS:
+        elif ext in features_util.RAPP_QUESTIONNAIRE_FILE_EXTENSIONS:
             return FeaturesService.from_rapp_questionnaire(database_session, projectId, fileObj, additional_files, original_path)
         else:
             raise ApiException("Filetype not supported for direct upload. Create a feature and attach as an asset?")
@@ -443,9 +405,9 @@ class FeaturesService:
         """
         fpath = pathlib.Path(fileObj.filename)
         ext = fpath.suffix.lstrip('.').lower()
-        if ext in FeaturesService.IMAGE_FILE_EXTENSIONS:
+        if ext in features_util.IMAGE_FILE_EXTENSIONS:
             fa = FeaturesService.createImageFeatureAsset(projectId, fileObj, original_path=original_path)
-        elif ext in FeaturesService.VIDEO_FILE_EXTENSIONS:
+        elif ext in features_util.VIDEO_FILE_EXTENSIONS:
             fa = FeaturesService.createVideoFeatureAsset(projectId, fileObj, original_path=original_path)
         else:
             raise ApiException("Invalid format for feature assets")

--- a/geoapi/services/features.py
+++ b/geoapi/services/features.py
@@ -13,7 +13,6 @@ import fiona
 from geoalchemy2.shape import from_shape
 import geojson
 
-
 from geoapi.services.images import ImageService, ImageData
 from geoapi.services.vectors import VectorService
 from geoapi.models import Feature, FeatureAsset, Overlay, User, TileServer

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -352,6 +352,8 @@ def import_from_files_from_path(session, tenant_id: str, userId: int, systemId: 
                     NotificationsService.create(session, user, "success", "Imported {f}".format(f=item_system_path))
                     tmp_file.close()
                 else:
+                    # skipping as not supported
+                    logger.debug("{path} is unsupported; skipping.".format(path=item_system_path))
                     continue
                 import_state = ImportState.SUCCESS
             except Exception as e:

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -357,11 +357,11 @@ def import_from_files_from_path(session, tenant_id: str, userId: int, systemId: 
                     continue
                 import_state = ImportState.SUCCESS
             except Exception as e:
-                logger.error(
-                    f"Could not import for user:{user.username} from agave:{systemId}/{item_system_path} "
-                    f"(while recursively importing files from {systemId}/{path})")
                 NotificationsService.create(session, user, "error", "Error importing {f}".format(f=item_system_path))
                 import_state = ImportState.FAILURE if e is not AgaveFileGetError else ImportState.RETRYABLE_FAILURE
+                logger.exception(
+                    f"Could not import for user:{user.username} from agave:{systemId}/{item_system_path} "
+                    f"(while recursively importing files from {systemId}/{path}). retryable={import_state == ImportState.RETRYABLE_FAILURE}")
             if import_state != ImportState.RETRYABLE_FAILURE:
                 try:
                     successful = True if import_state == ImportState.SUCCESS else False

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -311,7 +311,7 @@ def import_from_files_from_path(session, tenant_id: str, userId: int, systemId: 
 
                 # If it is a RApp project folder and not a questionnaire file, use the metadata from tapis meta service
                 if features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata(item_system_path):
-                    logger.info("RApp: importing:{} for user:{}. Using metadata service for geolocation.".format(item_system_path, user.username))
+                    logger.info(f"RApp: importing:{item_system_path} for user:{user.username}. Using metadata service for geolocation.")
                     try:
                         meta = get_metadata_using_service_account(tenant_id, item.system, item.path)
                     except MissingServiceAccount:
@@ -361,7 +361,8 @@ def import_from_files_from_path(session, tenant_id: str, userId: int, systemId: 
                 import_state = ImportState.FAILURE if e is not AgaveFileGetError else ImportState.RETRYABLE_FAILURE
                 logger.exception(
                     f"Could not import for user:{user.username} from agave:{systemId}/{item_system_path} "
-                    f"(while recursively importing files from {systemId}/{path}). retryable={import_state == ImportState.RETRYABLE_FAILURE}")
+                    f"(while recursively importing files from {systemId}/{path}). "
+                    f"retryable={import_state == ImportState.RETRYABLE_FAILURE}")
             if import_state != ImportState.RETRYABLE_FAILURE:
                 try:
                     successful = True if import_state == ImportState.SUCCESS else False

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -13,6 +13,7 @@ from geoapi.exceptions import InvalidCoordinateReferenceSystem, MissingServiceAc
 from geoapi.models import User, ProjectUser, ObservableDataProject, Task
 from geoapi.utils.agave import (AgaveUtils, SystemUser, get_system_users, get_metadata_using_service_account,
                                 AgaveFileGetError, AgaveListingError)
+from geoapi.utils import features as features_util
 from geoapi.log import logger
 from geoapi.services.features import FeaturesService
 from geoapi.services.imports import ImportsService
@@ -43,14 +44,6 @@ def _parse_rapid_geolocation(loc):
     lat = coords["latitude"]
     lon = coords["longitude"]
     return lat, lon
-
-
-def is_member_of_rapp_project_folder(path):
-    """
-    Check to see if path is contained within RApp project folder
-    :param path: str
-    """
-    return "/RApp/" in path
 
 
 def get_file(client, system_id, path, required):
@@ -305,11 +298,8 @@ def import_from_files_from_path(session, tenant_id: str, userId: int, systemId: 
     for item in files_in_directory:
         if item.type == "dir" and not str(item.path).endswith("/.Trash"):
             import_from_files_from_path(session, tenant_id, userId, systemId, item.path, projectId)
-        # skip any junk files that are not allowed
-        if item.path.suffix.lower().lstrip('.') not in FeaturesService.ALLOWED_EXTENSIONS:
-            continue
-        else:
-            item_system_path = os.path.join(item.system, str(item.path).lstrip("/"))
+        item_system_path = os.path.join(item.system, str(item.path).lstrip("/"))
+        if features_util.is_file_supported_for_automatic_scraping(item_system_path):
             try:
                 # first check if there already is a file in the DB
                 target_file = ImportsService.getImport(session, projectId, systemId, str(item.path))
@@ -319,16 +309,9 @@ def import_from_files_from_path(session, tenant_id: str, userId: int, systemId: 
                                  f"successful_import={target_file.successful_import}")
                     continue
 
-                # If it is a RApp project folder, grab the metadata from tapis meta service
-                if is_member_of_rapp_project_folder(item_system_path):
-                    logger.info("RApp: importing:{} for user:{}".format(item_system_path, user.username))
-                    if item.path.suffix.lower().lstrip(
-                            '.') not in FeaturesService.ALLOWED_GEOSPATIAL_FEATURE_ASSET_EXTENSIONS:
-                        logger.info("{path} is unsupported; skipping.".format(path=item_system_path))
-                        continue
-
-                    logger.info("{} {} {}".format(item_system_path, item.system, item.path))
-
+                # If it is a RApp project folder and not a questionnaire file, use the metadata from tapis meta service
+                if features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata(item_system_path):
+                    logger.info("RApp: importing:{} for user:{}. Using metadata service for geolocation.".format(item_system_path, user.username))
                     try:
                         meta = get_metadata_using_service_account(tenant_id, item.system, item.path)
                     except MissingServiceAccount:
@@ -359,7 +342,7 @@ def import_from_files_from_path(session, tenant_id: str, userId: int, systemId: 
                         raise RuntimeError("Unable to create feature asset")
                     NotificationsService.create(session, user, "success", "Imported {f}".format(f=item_system_path))
                     tmp_file.close()
-                elif item.path.suffix.lower().lstrip('.') in FeaturesService.ALLOWED_GEOSPATIAL_EXTENSIONS:
+                elif features_util.is_supported_for_automatic_scraping_without_metadata(item_system_path):
                     logger.info("importing:{} for user:{}".format(item_system_path, user.username))
                     tmp_file = client.getFile(systemId, item.path)
                     tmp_file.filename = Path(item.path).name
@@ -380,7 +363,7 @@ def import_from_files_from_path(session, tenant_id: str, userId: int, systemId: 
             if import_state != ImportState.RETRYABLE_FAILURE:
                 try:
                     successful = True if import_state == ImportState.SUCCESS else False
-                    # Save the row in the database that marks this file so we don't try to import it again
+                    # Save the row in the database that marks this file, so we don't try to import it again
                     target_file = ImportsService.createImportedFile(projectId=projectId,
                                                                     systemId=systemId,
                                                                     path=str(item.path),

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -366,7 +366,7 @@ def import_from_files_from_path(session, tenant_id: str, userId: int, systemId: 
             if import_state != ImportState.RETRYABLE_FAILURE:
                 try:
                     successful = True if import_state == ImportState.SUCCESS else False
-                    # Save the row in the database that marks this file, so we don't try to import it again
+                    # Save the row in the database that marks this file so we don't try to import it again
                     target_file = ImportsService.createImportedFile(projectId=projectId,
                                                                     systemId=systemId,
                                                                     path=str(item.path),

--- a/geoapi/tasks/streetview.py
+++ b/geoapi/tasks/streetview.py
@@ -24,7 +24,7 @@ from geoapi.utils.streetview import (get_project_streetview_dir,
                                      remove_project_streetview_dir,
                                      MapillaryUtils)
 from geoapi.log import logging
-import geoapi.services.features as features
+from geoapi.utils import features as features_util
 from geoapi.services.streetview import StreetviewService
 from geoapi.services.notifications import NotificationsService
 from geoapi.db import create_task_session
@@ -113,7 +113,7 @@ def _from_tapis(database_session, user: User, task_uuid: UUID, systemId: str, pa
     for item in files_in_directory:
         if item.type == "dir":
             continue
-        if item.path.suffix.lower().lstrip('.') not in features.FeaturesService.IMAGE_FILE_EXTENSIONS:
+        if item.path.suffix.lower().lstrip('.') not in features_util.IMAGE_FILE_EXTENSIONS:
             continue
         try:
             img_name = os.path.join(str(base_filepath), Path(item.path).name)

--- a/geoapi/tests/external_data_tests/test_external_data.py
+++ b/geoapi/tests/external_data_tests/test_external_data.py
@@ -8,8 +8,8 @@ from geoapi.db import db_session, create_task_session
 from geoapi.tasks.external_data import (import_from_agave,
                                         import_point_clouds_from_agave,
                                         refresh_observable_projects,
-                                        get_additional_files,
-                                        is_member_of_rapp_project_folder)
+                                        get_additional_files)
+from geoapi.utils.features import is_member_of_rapp_project_folder
 from geoapi.utils.agave import AgaveFileListing, SystemUser
 from geoapi.utils.assets import get_project_asset_dir, get_asset_path
 from geoapi.exceptions import InvalidCoordinateReferenceSystem

--- a/geoapi/tests/utils_tests/test_features.py
+++ b/geoapi/tests/utils_tests/test_features.py
@@ -1,0 +1,94 @@
+import pytest
+import geoapi.utils.features as features_util
+
+
+def test_is_member_of_rapp_project_folder():
+    assert not features_util.is_member_of_rapp_project_folder("/")
+    assert not features_util.is_member_of_rapp_project_folder("/foo/")
+
+    assert features_util.is_member_of_rapp_project_folder("/RApp/foo.txt")
+    assert features_util.is_member_of_rapp_project_folder("/RApp/bar/foo.txt")
+
+
+def test_is_member_of_rqa_folder():
+    assert not features_util.is_member_of_rqa_folder("/")
+    assert not features_util.is_member_of_rqa_folder("/foo/")
+
+    assert features_util.is_member_of_rqa_folder("/RApp/foo.rqa/test.rq")
+    assert features_util.is_member_of_rqa_folder("/bar/foo.rqa/test.jpg")
+
+
+def test_is_file_supported_for_automatic_scraping():
+    assert not features_util.is_file_supported_for_automatic_scraping("foo")
+    assert not features_util.is_file_supported_for_automatic_scraping("foo.txt")
+    assert not features_util.is_file_supported_for_automatic_scraping("foo.gif")
+    assert not features_util.is_file_supported_for_automatic_scraping("foo.ini")
+    assert not features_util.is_file_supported_for_automatic_scraping("foo.las")
+    assert not features_util.is_file_supported_for_automatic_scraping("foo.laz")
+
+    assert features_util.is_file_supported_for_automatic_scraping("foo.jpg")
+    assert features_util.is_file_supported_for_automatic_scraping("foo.JPG")
+    assert features_util.is_file_supported_for_automatic_scraping("foo.jpeg")
+    assert features_util.is_file_supported_for_automatic_scraping("foo.JPEG")
+
+    assert features_util.is_file_supported_for_automatic_scraping("foo.geojson")
+
+    assert features_util.is_file_supported_for_automatic_scraping("foo.mp4")
+    assert features_util.is_file_supported_for_automatic_scraping("foo.mov")
+    assert features_util.is_file_supported_for_automatic_scraping("foo.mpeg4")
+    assert features_util.is_file_supported_for_automatic_scraping("foo.webm")
+
+    assert features_util.is_file_supported_for_automatic_scraping("foo.gpx")
+
+    assert features_util.is_file_supported_for_automatic_scraping("foo.rq")
+
+    assert features_util.is_file_supported_for_automatic_scraping("foo.shp")
+
+def test_is_supported_for_automatic_scraping_without_metadata():
+    assert not features_util.is_supported_for_automatic_scraping_without_metadata("foo")
+    assert not features_util.is_supported_for_automatic_scraping_without_metadata("foo.txt")
+    assert not features_util.is_supported_for_automatic_scraping_without_metadata("foo.gif")
+    assert not features_util.is_supported_for_automatic_scraping_without_metadata("foo.ini")
+    assert not features_util.is_supported_for_automatic_scraping_without_metadata("foo.las")
+    assert not features_util.is_supported_for_automatic_scraping_without_metadata("foo.laz")
+    assert not features_util.is_supported_for_automatic_scraping_without_metadata("foo.mp4")
+
+    assert features_util.is_supported_for_automatic_scraping_without_metadata("foo.jpg")
+    assert features_util.is_supported_for_automatic_scraping_without_metadata("foo.JPG")
+    assert features_util.is_supported_for_automatic_scraping_without_metadata("foo.jpeg")
+    assert features_util.is_supported_for_automatic_scraping_without_metadata("foo.JPEG")
+
+    assert features_util.is_supported_for_automatic_scraping_without_metadata("foo.geojson")
+
+    assert features_util.is_supported_for_automatic_scraping_without_metadata("foo.gpx")
+
+    assert features_util.is_supported_for_automatic_scraping_without_metadata("foo.rq")
+
+    assert features_util.is_supported_for_automatic_scraping_without_metadata("foo.shp")
+
+
+def test_is_supported_file_type_in_rapp_folder_and_needs_metadata():
+    # not supported type
+    assert not features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo")
+    assert not features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.txt")
+    assert not features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.gif")
+    assert not features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.ini")
+    assert not features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.las")
+    assert not features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.laz")
+    assert not features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.geojson")
+    assert not features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.rq")
+    assert not features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.gpx")
+    assert not features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.shp")
+
+    # not in Rapp folder
+    assert not features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/bar/foo.jpg")
+
+    assert features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.jpg")
+    assert features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.JPG")
+    assert features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.jpeg")
+    assert features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.JPEG")
+
+    assert features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.mp4")
+    assert features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.mov")
+    assert features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.mpeg4")
+    assert features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata("/RApp/foo.webm")

--- a/geoapi/tests/utils_tests/test_features.py
+++ b/geoapi/tests/utils_tests/test_features.py
@@ -1,4 +1,3 @@
-import pytest
 import geoapi.utils.features as features_util
 
 
@@ -43,6 +42,7 @@ def test_is_file_supported_for_automatic_scraping():
     assert features_util.is_file_supported_for_automatic_scraping("foo.rq")
 
     assert features_util.is_file_supported_for_automatic_scraping("foo.shp")
+
 
 def test_is_supported_for_automatic_scraping_without_metadata():
     assert not features_util.is_supported_for_automatic_scraping_without_metadata("foo")

--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -142,7 +142,7 @@ class AgaveUtils:
         out = {k: v for d in results for k, v in d.items()}
         return out
 
-    def _get_file(self, systemId: str, path: str, use_service_account: bool = False) -> IO:
+    def _get_file(self, systemId: str, path: str, use_service_account: bool = False) -> NamedTemporaryFile:
         """
         Get file
 
@@ -194,7 +194,7 @@ class AgaveUtils:
                 raise RetryableTapisFileError
         return tmpFile
 
-    def getFile(self, systemId: str, path: str) -> IO:
+    def getFile(self, systemId: str, path: str) -> NamedTemporaryFile:
         """
         Download a file from tapis
 

--- a/geoapi/utils/features.py
+++ b/geoapi/utils/features.py
@@ -82,7 +82,7 @@ def is_supported_for_automatic_scraping_without_metadata(path):
     path_obj = Path(path)
     file_suffix = path_obj.suffix.lower().lstrip('.')
     return (file_suffix in ALLOWED_GEOSPATIAL_EXTENSIONS_FOR_SCRAPING and
-            (not is_member_of_rqa_folder(path) or file_suffix in RAPP_QUESTIONNAIRE_FILE_EXTENSIONS)) # if in .rqa, then only .rq file
+            (not is_member_of_rqa_folder(path) or file_suffix in RAPP_QUESTIONNAIRE_FILE_EXTENSIONS))  # if in .rqa, then only .rq file
 
 
 def is_supported_file_type_in_rapp_folder_and_needs_metadata(path):

--- a/geoapi/utils/features.py
+++ b/geoapi/utils/features.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+GEOJSON_FILE_EXTENSIONS = (
+    'json', 'geojson'
+)
+
+IMAGE_FILE_EXTENSIONS = (
+    'jpeg', 'jpg',
+)
+
+VIDEO_FILE_EXTENSIONS = (
+    'mp4', 'mov', 'mpeg4', 'webm'
+)
+
+# TODO not used; remove from code base
+AUDIO_FILE_EXTENSIONS = (
+    'mp3', 'aac'
+)
+
+GPX_FILE_EXTENSIONS = (
+    'gpx',
+)
+
+SHAPEFILE_FILE_EXTENSIONS = (
+    'shp',
+)
+
+RAPP_QUESTIONNAIRE_FILE_EXTENSIONS = (
+    'rq',
+)
+
+RAPP_QUESTIONNAIRE_ARCHIVE_EXTENSIONS = 'rqa'
+
+ALLOWED_GEOSPATIAL_FEATURE_ASSET_EXTENSIONS = IMAGE_FILE_EXTENSIONS + VIDEO_FILE_EXTENSIONS
+
+INI_FILE_EXTENSIONS = (
+    'ini',
+)
+
+# Files who can be directly imported (with or without Tapis metadata)
+ALLOWED_GEOSPATIAL_EXTENSIONS_FOR_SCRAPING = IMAGE_FILE_EXTENSIONS + GPX_FILE_EXTENSIONS + GEOJSON_FILE_EXTENSIONS +\
+    SHAPEFILE_FILE_EXTENSIONS + RAPP_QUESTIONNAIRE_FILE_EXTENSIONS
+
+
+def is_member_of_rapp_project_folder(path):
+    """
+    Check to see if path is contained within RApp project folder
+    :param path: str
+    """
+    return "/RApp/" in path
+
+
+def is_member_of_rqa_folder(path):
+    """
+    Check to see if path is contained within RApp project folder
+    :param path: str
+    """
+    path_obj = Path(path)
+    return path_obj.parent and path_obj.parent.name.endswith('.' + RAPP_QUESTIONNAIRE_ARCHIVE_EXTENSIONS)
+
+
+def is_file_supported_for_automatic_scraping(path):
+    """
+    Check to see if file has a type supported for automatic importing
+    :param path: str
+    """
+    path_obj = Path(path)
+    suffix = path_obj.suffix.lower().lstrip('.')
+    return (suffix in ALLOWED_GEOSPATIAL_EXTENSIONS_FOR_SCRAPING or  # supported files (with or without Tapis metadata)
+            suffix in ALLOWED_GEOSPATIAL_FEATURE_ASSET_EXTENSIONS)  # with metadata (i.e. within /Rapp folder)
+
+
+def is_supported_for_automatic_scraping_without_metadata(path):
+    """
+    Check to see if file is supported for automatic importing (without metadata).
+
+    Note: assets like images inside the questionnaire archive (i.e in .rqa) should be ignored. Only the
+    .rq file inside a .rqa file should be imported.
+
+    :param path: str
+    """
+    path_obj = Path(path)
+    file_suffix = path_obj.suffix.lower().lstrip('.')
+    return (file_suffix in ALLOWED_GEOSPATIAL_EXTENSIONS_FOR_SCRAPING and
+            (not is_member_of_rqa_folder(path) or file_suffix in RAPP_QUESTIONNAIRE_FILE_EXTENSIONS)) # if in .rqa, then only .rq file
+
+
+def is_supported_file_type_in_rapp_folder_and_needs_metadata(path):
+    """
+    Check if file is in /Rapp folder and is importable and if Tapis metadata service should be used to derive
+    the file's geolocation
+
+    This applies to image and video files (i.e. ALLOWED_GEOSPATIAL_FEATURE_ASSET_EXTENSIONS) in the RApp project folder
+    but the exception is the image and video files within the .rqa folder.
+
+    :param path: str
+    """
+    path_obj = Path(path)
+    return (is_member_of_rapp_project_folder(path)
+            and path_obj.suffix.lower().lstrip('.') in ALLOWED_GEOSPATIAL_FEATURE_ASSET_EXTENSIONS
+            and not is_member_of_rqa_folder(path))


### PR DESCRIPTION
## Overview: ##

This PR adds support the scraping of questionnaires. It ensures the questionnaires in connected projects are scraped and that any asset images aren't inadvertently scrapped twice.

This PR also:
* refactors how we determine which files to scrape
* removes audio file formats that were not used

## Related Jira tickets: ##

* [WG-170](https://jira.tacc.utexas.edu/browse/WG-170)

## Summary of Changes: ##

## Testing Steps: ##



1. Use hazmapper's `feature/questionnaire` when running hazmapper
2. Create a new map and select top level dir of shared project "Questionnaire_Example".  ensure "Sync Folder" is checked. (See screenshot below)
3. Click "Submit"
4. See that one questionnaire is imported correctly. and that its asset images aren't incorrectly imported as individual assets.
5. Note that there will be some log errors as there are some questionnaire files in the /Rapp folder that do not have a geolocation.  I can remove those if we want a cleaner project to test thing with.

![Screenshot 2023-10-26 at 4 40 52 PM](https://github.com/TACC-Cloud/geoapi/assets/8287580/f43775b7-d162-4454-a497-6b4d9378db50)


