### PR TITLE
Add handling of preflight requests in assets

### DIFF
--- a/devops/geoapi-services/nginx.conf
+++ b/devops/geoapi-services/nginx.conf
@@ -48,6 +48,17 @@ http {
           max_ranges 0;
           expires 30d;
           add_header "Access-Control-Allow-Origin"  *;
+
+          # Preflighted requests
+          if ($request_method = OPTIONS ) {
+              add_header "Access-Control-Allow-Origin"  *;
+              add_header "Access-Control-Allow-Methods" "GET, POST, OPTIONS, HEAD, PUT, DELETE";
+              add_header "Access-Control-Allow-Headers" "*";
+              add_header 'Access-Control-Max-Age' 1728000;
+              add_header 'Content-Length' 0;
+              return 204;
+          }
+
           alias /assets/;
       }
     }


### PR DESCRIPTION
## Overview: ##

Add preflight requests for assets route.  This was in the kube nginx conf but missed it in the transition to VMs.  

Currently, this is breaking our questionnaire work: 
<img width="1685" alt="Screenshot 2023-11-13 at 3 17 57 PM" src="https://github.com/TACC-Cloud/geoapi/assets/8287580/f9357317-88e6-4141-a9ef-890b15b2724a">

## Related Jira tickets: ##

None

## Testing Steps: ##
1. Deployed via https://github.com/TACC-Cloud/wma-geospatial-deployments/commit/a2704a5484f1c0daf57ea099f53c34b1b078a468 to staging: https://hazmapper.tacc.utexas.edu/staging/

## Notes ###

https://github.com/TACC-Cloud/geoapi/pull/157/files#r1385415551 comment should be considered here.  I think so many examples have such a long cache time for **"preflight requests"** is cause "why not" but then chrome or the browser might choose a lower time.

* https://enable-cors.org/server_nginx.html
* https://stackoverflow.com/questions/15381105/what-is-the-motivation-behind-the-introduction-of-preflight-cors-requests  



