### PR TITLE
hotfix: remove LAStools building step

### DIFF
--- a/devops/Dockerfile.worker
+++ b/devops/Dockerfile.worker
@@ -11,9 +11,6 @@ unzip git wget libc6-dev gcc-multilib
 
 WORKDIR /opt
 
-RUN mkdir tools && cd tools && git clone --depth 1 https://github.com/LAStools/LAStools && cd LAStools/ && make all && make clean && rm -rf data
-ENV PATH /opt/tools/LAStools/bin/:$PATH
-
 RUN git clone --depth 1 https://github.com/m-schuetz/LAStools.git && cd LAStools/LASzip && mkdir build && cd build && \
 cmake -DCMAKE_BUILD_TYPE=Release .. && make && make install && ldconfig
 


### PR DESCRIPTION

## Overview: ##

LASTools is failing at the moment in our Dockerfile.  We no longe run lasinfo to read crs from las files (we use pdal now for that).  So we no longer need this step and can just remote it.


## Related Jira tickets: ##

None

