### PR TITLE
task/WG-138-WG-140: improve logs for analytics to include application and related DS system

### DIFF
--- a/geoapi/models/project.py
+++ b/geoapi/models/project.py
@@ -29,6 +29,8 @@ class Project(Base):
     id = Column(Integer, primary_key=True)
     uuid = Column(UUID(as_uuid=True), default=uuid.uuid4, nullable=False)
     tenant_id = Column(String, nullable=False)
+    # Project system_id/system_path really not used except for analytics.
+    # This could be improved; see https://jira.tacc.utexas.edu/browse/WG-185
     system_id = Column(String, nullable=True)
     system_path = Column(String, nullable=True)
     system_file = Column(String, nullable=True)

--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -169,7 +169,7 @@ class ProjectsListing(Resource):
         uuid_subset = query.get("uuid")
 
         if uuid_subset:
-            logger.info(f"Getting a subset of projects for user:{u.username} projects:{uuid_subset}")
+            logger.info(f"Getting a subset of projects for user:{u.username} project_uuid:{uuid_subset}")
 
             # Check each project and abort if user (authenticated or anonymous) can't access the project
             subset = [check_access_and_get_project(request.current_user, uuid=uuid, allow_public_use=True) for uuid in uuid_subset]
@@ -181,7 +181,7 @@ class ProjectsListing(Resource):
             project_ids = [p.id for p in subset]
             system_ids = [p.system_id for p in subset]
             logger.info(f"Got a subset of projects for user:{u.username} application:{application}"
-                        f" projects:{uuid_subset} project_ids:{project_ids} tapis_system_ids:{system_ids}")
+                        f" project_uuid:{uuid_subset} project:{project_ids} tapis_system_id:{system_ids}")
             return subset
         else:
             if is_anonymous(u):

--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -300,9 +300,12 @@ class ProjectFeaturesResource(Resource):
             if application is None:
                 application = "Unknown"
 
+        is_public_view = any(base.__name__ == 'PublicProjectFeaturesResource' for base in self.__class__.__bases__)
+
         prj = ProjectsService.get(db_session, project_id=projectId, user=request.current_user)
         logger.info(f"Get features of project for user:{request.current_user.username} application:{application}"
-                    f" project_uuid:{prj.uuid} project:{prj.id} tapis_system_id:{prj.system_id}")
+                    f" public_view:{is_public_view} project_uuid:{prj.uuid} project:{prj.id} tapis_system_id:{prj.system_id} "
+                    f"tapis_system_path:{prj.system_path}")
 
         query = self.parser.parse_args()
         return ProjectsService.getFeatures(db_session, projectId, query)

--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -294,7 +294,12 @@ class ProjectFeaturesResource(Resource):
         # Following log is for analytics, see https://confluence.tacc.utexas.edu/display/DES/Hazmapper+Logging
         application = request.headers.get('X-Geoapi-Application')
         if application is None:
-            application = "Unknown"
+            #  Check if in query parameters due to https://tacc-main.atlassian.net/browse/WG-192 and WG-191 */
+            application = request.args.get('application')
+
+            if application is None:
+                application = "Unknown"
+
         prj = ProjectsService.get(db_session, project_id=projectId, user=request.current_user)
         logger.info(f"Get features of project for user:{request.current_user.username} application:{application}"
                     f" project_uuid:{prj.uuid} project:{prj.id} tapis_system_id:{prj.system_id}")

--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -300,7 +300,8 @@ class ProjectFeaturesResource(Resource):
             if application is None:
                 application = "Unknown"
 
-        is_public_view = any(base.__name__ == 'PublicProjectFeaturesResource' for base in self.__class__.__bases__)
+        from geoapi.routes.public_projects import PublicProjectFeaturesResource
+        is_public_view = issubclass(self.__class__, PublicProjectFeaturesResource)
 
         prj = ProjectsService.get(db_session, project_id=projectId, user=request.current_user)
         logger.info(f"Get features of project for user:{request.current_user.username} application:{application}"

--- a/geoapi/tests/api_tests/test_projects_routes.py
+++ b/geoapi/tests/api_tests/test_projects_routes.py
@@ -295,6 +295,7 @@ def test_get_project_features_empty_public_access(test_client, public_projects_f
                                    f"tapis_system_id:None tapis_system_path:None")
     assert log_statement_for_analytics in caplog.text
 
+
 def test_get_project_features_analytics_with_query_params(test_client, public_projects_fixture, caplog):
     # send analytics-related params to projects endpoint only (until we use headers again
     # in https://tacc-main.atlassian.net/browse/WG-192)

--- a/geoapi/tests/api_tests/test_projects_routes.py
+++ b/geoapi/tests/api_tests/test_projects_routes.py
@@ -52,7 +52,7 @@ def test_get_projects_using_uuids(test_client, projects_fixture, projects_fixtur
     assert data[1]["uuid"] == requested_uuids[1]
 
 
-def test_get_projects_using_single_uuid(test_client, projects_fixture, projects_fixture2, user1, caplog):
+def test_get_projects_using_single_uuid(test_client, projects_fixture, projects_fixture2, user1):
     resp = test_client.get('/projects/',
                            query_string='uuid={}'.format(projects_fixture2.uuid),
                            headers={'x-jwt-assertion-test': user1.jwt})
@@ -61,12 +61,9 @@ def test_get_projects_using_single_uuid(test_client, projects_fixture, projects_
     assert len(data) == 1
     assert data[0]["uuid"] == str(projects_fixture2.uuid)
     assert data[0]["deletable"] is True
-    log_statement_for_analytics = (f"Got a subset of projects for user:{user1.username} application:Unknown "
-                                   f"projects:['{projects_fixture2.uuid}'] project_ids:[2] tapis_system_ids:[None]")
-    assert log_statement_for_analytics in caplog.text
 
 
-def test_get_projects_using_single_uuid_observable_project(test_client, observable_projects_fixture, user1, caplog):
+def test_get_projects_using_single_uuid_observable_project(test_client, observable_projects_fixture, user1):
     resp = test_client.get('/projects/',
                            query_string='uuid={}'.format(observable_projects_fixture.project.uuid),
                            headers={'x-jwt-assertion-test': user1.jwt})
@@ -74,10 +71,6 @@ def test_get_projects_using_single_uuid_observable_project(test_client, observab
     assert resp.status_code == 200
     assert len(data) == 1
     assert data[0]["uuid"] == str(observable_projects_fixture.project.uuid)
-    log_statement_for_analytics = (f"Got a subset of projects for user:{user1.username} application:Unknown "
-                                   f"projects:['{observable_projects_fixture.project.uuid}'] project_ids:[1] "
-                                   f"tapis_system_ids:['testSystem']")
-    assert log_statement_for_analytics in caplog.text
 
 
 def test_get_projects_using_single_uuid_that_is_wrong(test_client, user1):
@@ -87,13 +80,10 @@ def test_get_projects_using_single_uuid_that_is_wrong(test_client, user1):
     assert resp.status_code == 404
 
 
-def test_get_public_project_using_single_uuid(test_client, public_projects_fixture, caplog):
+def test_get_public_project_using_single_uuid(test_client, public_projects_fixture):
     resp = test_client.get('/projects/',
                            query_string='uuid={}'.format(public_projects_fixture.uuid))
     assert resp.status_code == 200
-    log_statement_for_analytics = (f"Got a subset of projects for user:Guest_Unknown application:Unknown "
-                                   f"projects:['{public_projects_fixture.uuid}'] project_ids:[1] tapis_system_ids:[None]")
-    assert log_statement_for_analytics in caplog.text
 
 
 def test_get_project_using_single_uuid_unauthorized_guest(test_client, projects_fixture):
@@ -282,20 +272,38 @@ def test_get_point_cloud(test_client, projects_fixture, point_cloud_fixture, use
     assert resp.status_code == 200
 
 
-def test_get_project_features_empty(test_client, projects_fixture, user1):
+def test_get_project_features_empty(test_client, projects_fixture, user1, caplog):
     resp = test_client.get(f'/projects/{projects_fixture.id}/features/',
                            headers={'x-jwt-assertion-test': user1.jwt})
     assert resp.status_code == 200
 
     data = resp.get_json()
     assert len(data['features']) == 0
+    log_statement_for_analytics = (f"Get features of project for user:{user1.username} application:Unknown public_view:False "
+                                   f"project_uuid:{projects_fixture.uuid} project:{projects_fixture.id} "
+                                   f"tapis_system_id:None tapis_system_path:None")
+    assert log_statement_for_analytics in caplog.text
 
 
-def test_get_project_features_empty_public_access(test_client, public_projects_fixture):
-    resp = test_client.get('/projects/{}/features/'.format(public_projects_fixture.id))
+def test_get_project_features_empty_public_access(test_client, public_projects_fixture, caplog):
+    resp = test_client.get('/public-projects/{}/features/'.format(public_projects_fixture.id))
     assert resp.status_code == 200
     data = resp.get_json()
     assert len(data['features']) == 0
+    log_statement_for_analytics = (f"Get features of project for user:Guest_Unknown application:Unknown public_view:True "
+                                   f"project_uuid:{public_projects_fixture.uuid} project:{public_projects_fixture.id} "
+                                   f"tapis_system_id:None tapis_system_path:None")
+    assert log_statement_for_analytics in caplog.text
+
+def test_get_project_features_analytics_with_query_params(test_client, public_projects_fixture, caplog):
+    # send analytics-related params to projects endpoint only (until we use headers again
+    # in https://tacc-main.atlassian.net/browse/WG-192)
+    query = {'application': 'hazmapper', 'guest_uuid': "1234"}
+    test_client.get('/public-projects/{}/features/'.format(public_projects_fixture.id), query_string=query)
+    log_statement_for_analytics = (f"Get features of project for user:Guest_1234 application:hazmapper public_view:True "
+                                   f"project_uuid:{public_projects_fixture.uuid} project:{public_projects_fixture.id} "
+                                   f"tapis_system_id:None tapis_system_path:None")
+    assert log_statement_for_analytics in caplog.text
 
 
 def test_get_project_features_single_feature(test_client, projects_fixture, feature_fixture, user1):

--- a/geoapi/tests/conftest.py
+++ b/geoapi/tests/conftest.py
@@ -113,7 +113,7 @@ def public_projects_fixture(projects_fixture):
 
 
 @pytest.fixture(scope="function")
-def observable_projects_fixture():
+def observable_projects_fixture(user1):
     u1 = db_session.query(User).filter(User.username == "test1").first()
     proj = Project(name="test_observable",
                    description="description",
@@ -123,6 +123,12 @@ def observable_projects_fixture():
         path="/testPath",
         watch_content=True
     )
+
+    # Project system_id/system_path really not used except for analytics.
+    # This could be improved; see https://jira.tacc.utexas.edu/browse/WG-185
+    proj.system_id = obs.system_id
+    proj.system_path = obs.path
+
     obs.project = proj
     proj.users.append(u1)
     db_session.add(obs)

--- a/geoapi/tests/conftest.py
+++ b/geoapi/tests/conftest.py
@@ -113,7 +113,7 @@ def public_projects_fixture(projects_fixture):
 
 
 @pytest.fixture(scope="function")
-def observable_projects_fixture(user1):
+def observable_projects_fixture():
     u1 = db_session.query(User).filter(User.username == "test1").first()
     proj = Project(name="test_observable",
                    description="description",

--- a/geoapi/utils/decorators.py
+++ b/geoapi/utils/decorators.py
@@ -35,6 +35,9 @@ def jwt_decoder(fn):
         except ValueError:
             # if not JWT information is provided in header, then this is a guest user
             guest_uuid = request.headers.get('X-Guest-UUID')
+            if guest_uuid is None:
+                #  Check if in query parameters due to https://tacc-main.atlassian.net/browse/WG-192 and WG-191 */
+                guest_uuid = request.args.get('guest_uuid')
             user = AnonymousUser(guest_unique_id=guest_uuid)
         if user is None:
             try:


### PR DESCRIPTION
## Overview: ##

This PR adds the following additional information to logs for analytics on the `features` endpoint:
* application information (i.e. "taggit", "hazmapper")
*  DesignSafe project information (e.g. "project-8131157524548227566-242ac117-0001-012" which is tapis system name of DesignSafe project)
* is this route being used for the public view of a map


Here are (**updated example on Dec 8th**) examples.

Taggit:
```
Get features of project for user:nathanf application:hazmapper public_view:False project_uuid:a5114ec8-030b-4cff-aa01-1a4a05d1cb88 project:6 tapis_system_id:designsafe.storage.default tapis_system_path:/nathanf
````

Hazmapper (logged in and private map):
```
Get features of project for user:nathanf application:hazmapper public_view:False project_uuid:2aa6f441-5762-438c-bda2-1a2c18b1ddac project:5 tapis_system_id:project-3891343857756007955-242ac117-0001-012 tapis_system_path:/
```

Hazmapper (not logged in and public map):
```
Get features of project for user:Guest_e8f69653-9a77-444a-887a-e9e476a8cf25 application:hazmapper public_view:False project_uuid:2aa6f441-5762-438c-bda2-1a2c18b1ddac project:5 tapis_system_id:project-3891343857756007955-242ac117-0001-012 tapis_system_path:/
```

**Note**:  We first thought we would use the request's header's referrer to determine app. As our request is cross origin and only origin (not path like /hazmapper or /taggit) are shared shared typically for safety concerns: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#strict-origin-when-cross-origin.

**Note**: @sophia-massie , now the route used for analytic-related logging is connected to the feature route (e.g. `/projects/{projectId}/features` or  `/public-projects/{projectId}/features`) which is used by both Taggit and Hazmapper

So related PRs in taggit and hazmapper report are adding the applicaiton name to the header and using that instead of the referrer.

So see related PRs:
* ~https://github.com/TACC-Cloud/hazmapper/pull/170~ (merged)
* https://github.com/TACC-Cloud/hazmapper/pull/180
* https://github.com/taggit-tacc/taggit/pull/119

## Related Jira tickets: ##

* [WG-138](https://jira.tacc.utexas.edu/browse/WG-138)
* [WG-140](https://jira.tacc.utexas.edu/browse/WG-140)

## Summary of Changes: ##

## Testing Steps: ##
1. Use related hazmapper or taggit PRs.
2. View a map/gallery in hazmapper or taggit.
4. Check that the backend log statements look correct
5. View a public map in hazmapper (optional)
6. Check that the logs look correct

## Notes: ##

https://tacc-team.slack.com/archives/C05N3EMV5E2/p1693516925100069?thread_ts=1692815984.311629&cid=C05N3EMV5E2

https://confluence.tacc.utexas.edu/display/DES/Hazmapper+Logging+and+Analytics.  (**Needs to be updated by Nathan when back online**)
