### PR TITLE
task/WG-182: adding additional logging for project uuid upon deletion

### DIFF
--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -210,13 +210,9 @@ class ProjectResource(Resource):
         u = request.current_user
         # Retrieve the project using the projectId to get its UUID
         project = ProjectsService.get(db_session, project_id=projectId, user=u)
-        # Check if the project exists and log the information including the UUID
-        if project:
-            logger.info("Delete project:{} with UUID:{} for user:{}".format(
+        logger.info("Delete project:{} with project_uuid:{} for user:{}".format(
                 projectId, project.uuid, u.username))
-            return ProjectsService.delete(db_session, u, projectId)
-        else:
-            abort(404, "Project not found")
+        return ProjectsService.delete(db_session, u, projectId)
 
     @api.doc(id="updateProject",
              description="Update metadata about a project")

--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -208,9 +208,15 @@ class ProjectResource(Resource):
     @project_admin_or_creator_permissions
     def delete(self, projectId: int):
         u = request.current_user
-        logger.info("Delete project:{} for user:{}".format(projectId,
-                                                           u.username))
-        return ProjectsService.delete(db_session, u, projectId)
+        # Retrieve the project using the projectId to get its UUID
+        project = ProjectsService.get(db_session, project_id=projectId, user=u)
+        # Check if the project exists and log the information including the UUID
+        if project:
+            logger.info("Delete project:{} with UUID:{} for user:{}".format(
+            projectId, project.uuid, u.username))
+            return ProjectsService.delete(db_session, u, projectId)
+        else:
+            abort(404, "Project not found")
 
     @api.doc(id="updateProject",
              description="Update metadata about a project")

--- a/geoapi/routes/projects.py
+++ b/geoapi/routes/projects.py
@@ -213,7 +213,7 @@ class ProjectResource(Resource):
         # Check if the project exists and log the information including the UUID
         if project:
             logger.info("Delete project:{} with UUID:{} for user:{}".format(
-            projectId, project.uuid, u.username))
+                projectId, project.uuid, u.username))
             return ProjectsService.delete(db_session, u, projectId)
         else:
             abort(404, "Project not found")


### PR DESCRIPTION
## Overview: ##
Improve logging of delete to include UUID with project ID. See notes of the related [WG-70](https://jira.tacc.utexas.edu/browse/WG-70) issue of why this is needed. 

In https://github.com/TACC-cloud/geoapi
in geoapi/routes/projects.py

## Related Jira tickets: ##

* [WG-182](https://jira.tacc.utexas.edu/browse/WG-182)

## Summary of Changes: ##

- Improved logging of delete to include UUID

## Testing Steps: ##

1. Navigate to geoapi repo and run 'make start'
2. Run this command 'curl -H X-JWT-Assertion-designsafe:$JWT localhost:8000/projects/' to list the current projects
3. Pick a project that's ok to delete and use its projectid in this next command
4. curl -X 'DELETE' \\
  'http://localhost:8000/projects/1/' \\
  -H X-JWT-Assertion-designsafe:$JWT
5. Should get a 'status': 'ok' response from api
6. Run this command again 'curl -H X-JWT-Assertion-designsafe:$JWT localhost:8000/projects/'
7. You shouldn't see the project you deleted in your project listing anymore. 
8. Also go to Docker Desktop and find the 'geoapi' container. 
9. In the logs of that container you should see something like this:

Delete project:1 with UUID:2b097db7-d370-40c5-a632-6ed441ca47a5 for user:tgrafft

10. Compare with screenshots below

## UI: ##
<img width="570" alt="Screenshot 2023-11-29 at 9 33 08 AM" src="https://github.com/TACC-Cloud/geoapi/assets/50084480/7278f6bd-6e19-4a8b-9c9d-9182fc44acf7">
<img width="570" alt="Screenshot 2023-11-29 at 9 33 29 AM" src="https://github.com/TACC-Cloud/geoapi/assets/50084480/597ee1d7-af99-4a4f-a10f-056987e69e8b">
<img width="1006" alt="Screenshot 2023-11-29 at 9 32 36 AM" src="https://github.com/TACC-Cloud/geoapi/assets/50084480/af820244-4c9a-4e49-a609-77a650979159">


## Notes: ##
