### PR TITLE
task/WG-67: Adding JWT verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,21 +31,15 @@ under gunicorn on port 8000
 
 `docker exec -it geoapi python initdb.py`
 
-###### Create a JWT
+###### Obtain a JWT
 
-Copy this string to here: https://jwt.io/ 
-
-```
-eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3c28yLm9yZy9wcm9kdWN0cy9hbSIsImV4cCI6MjM4NDQ4MTcxMzg0MiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9zdWJzY3JpYmVyIjoiWU9VUl9VU0VSTkFNRSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvYXBwbGljYXRpb25pZCI6IjQ0IiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9hcHBsaWNhdGlvbm5hbWUiOiJEZWZhdWx0QXBwbGljYXRpb24iLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2FwcGxpY2F0aW9udGllciI6IlVubGltaXRlZCIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvYXBpY29udGV4dCI6Ii9hcHBzIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy92ZXJzaW9uIjoiMi4wIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy90aWVyIjoiVW5saW1pdGVkIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9rZXl0eXBlIjoiUFJPRFVDVElPTiIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvdXNlcnR5cGUiOiJBUFBMSUNBVElPTl9VU0VSIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9lbmR1c2VyIjoiWU9VUl9VU0VSTkFNRSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvZW5kdXNlclRlbmFudElkIjoiMTAiLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2VtYWlsYWRkcmVzcyI6InRlc3R1c2VyM0B0ZXN0LmNvbSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvZnVsbG5hbWUiOiJEZXYgVXNlciIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvZ2l2ZW5uYW1lIjoiRGV2IiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9sYXN0bmFtZSI6IlVzZXIiLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL3ByaW1hcnlDaGFsbGVuZ2VRdWVzdGlvbiI6Ik4vQSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvcm9sZSI6IkludGVybmFsL2V2ZXJ5b25lIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy90aXRsZSI6Ik4vQSJ9.0dIfuYvmXJwES1m1NJKKAPclynbGnaxzX3ygSz-3dqA
-```
-
-Edit the `YOUR_USERNAME`s in there for your TACC username and copy the modified string
+Refer to the confluence page or ask a colleague for assistance in obtaining a JWT.
 
 ###### Make some requests
 
 You need to add the following header for authentication:
 
-`X-JWT-Assertion` to equal the JWT created above
+`X-JWT-Assertion-designsafe` to equal the JWT obtained above
 
 ###### Create a new map project
 

--- a/geoapi/utils/decorators.py
+++ b/geoapi/utils/decorators.py
@@ -46,7 +46,7 @@ def jwt_decoder(fn):
 
             # Exceptions
             except Exception as e:
-                logger.error(e)
+                logger.error(f'There is an issue decoding the JWT: {e}')
                 abort(400, f'There is an issue decoding the JWT: {e}')
 
             user = UserService.getUser(db_session, username, tenant)

--- a/geoapi/utils/decorators.py
+++ b/geoapi/utils/decorators.py
@@ -47,7 +47,7 @@ def jwt_decoder(fn):
                 # we get from the header anyway
                 username = username.split("@")[0]
 
-            #Possible exceptions
+            # Possible exceptions
             except jwt.ExpiredSignatureError:
                 logger.info('Token Expired')
                 abort(401, 'Token expired')


### PR DESCRIPTION
## Overview: ##
Add jwt verification to geoapi

## Related Jira tickets: ##

* [WG-67](https://jira.tacc.utexas.edu/browse/WG-67)

## Summary of Changes: ##

- Before in our ReadMe file we were obtaining a JWT manually through an external site. This JWT was using the HS256 algorithm. We were not requiring it to be verified.
- Using the same JWT (from external site) was a problem when adding verification bc we were using two different algorithms (HS256 and RS256). Since the pub_key and token are different algorithms, this would cause the decoding to fail when attempting verification. 
- In order to fix this I changed the algorithm we were decoding with to be RS256 to match the pub key
- With these changes, this requires the devs to obtain their real JWT (which is also RS256). Instructions on how to get this will be provided, if you don't have this already.
- I added a conditional to not require verification when in the testing env (so that a majority of our test wouldn't fail)
- Added additional exception logging for JWT verification to help any issues.

## Testing Steps: ##
1. Obtain real JWT (instructions provided, if needed)
2. Replace old external JWT (HS256 algo) with the new JWT (RS256) in the client side (jwt.ts file)
3. Go to localhost:4200 and test that you can see your project listings. 
4. Make sure no errors were logged and that there's no "Failed to connect to localhost:8888" message when trying to list your projects. (This is JWT-related, if so)

## Notes: ##
