### PR TITLE
task/WG-211 update metadata query to support DES-2636

### DIFF
--- a/geoapi/services/features.py
+++ b/geoapi/services/features.py
@@ -257,7 +257,8 @@ class FeaturesService:
                 # gather coordinates information for this asset
                 logger.debug(f"{asset_file_obj.filename} has the geospatial coordinates of {processed_asset_image.coordinates}")
                 additional_files_properties.append({"filename": base_filename,
-                                                    "coordinates": (processed_asset_image.coordinates.longitude, processed_asset_image.coordinates.latitude)})
+                                                    "coordinates": (processed_asset_image.coordinates.longitude,
+                                                                    processed_asset_image.coordinates.latitude)})
                 asset_file_obj.close()
 
         if additional_files_properties:
@@ -349,7 +350,8 @@ class FeaturesService:
             raise ApiException("Filetype not supported for direct upload. Create a feature and attach as an asset?")
 
     @staticmethod
-    def fromImage(database_session, projectId: int, fileObj: IO, metadata: Dict, original_path: str = None, location: GeoLocation = None) -> Feature:
+    def fromImage(database_session, projectId: int, fileObj: IO, metadata: Dict,
+                  original_path: str = None, location: GeoLocation = None) -> Feature:
         """
         Create a Point feature from a georeferenced image
 

--- a/geoapi/services/features.py
+++ b/geoapi/services/features.py
@@ -16,12 +16,14 @@ import geojson
 from geoapi.services.images import ImageService, ImageData
 from geoapi.services.vectors import VectorService
 from geoapi.models import Feature, FeatureAsset, Overlay, User, TileServer
-from geoapi.exceptions import InvalidGeoJSON, ApiException
+from geoapi.exceptions import InvalidGeoJSON, ApiException, InvalidEXIFData, InvalidCoordinateReferenceSystem
 from geoapi.utils.assets import make_project_asset_dir, delete_assets, get_asset_relative_path
 from geoapi.log import logging
 from geoapi.utils import (geometries,
                           features as features_util)
 from geoapi.utils.agave import AgaveUtils
+from geoapi.utils.geo_location import GeoLocation, parse_rapid_geolocation
+
 
 logger = logging.getLogger(__name__)
 
@@ -134,8 +136,8 @@ class FeaturesService:
         return feat
 
     @staticmethod
-    def fromLatLng(database_session, projectId: int, lat: float, lng: float, metadata: Dict) -> Feature:
-        point = Point(lng, lat)
+    def fromLatLng(database_session, projectId: int, location: GeoLocation, metadata: Dict) -> Feature:
+        point = Point(location.longitude, location.latitude)
         f = Feature()
         f.project_id = projectId
         f.the_geom = from_shape(point, srid=4326)
@@ -218,9 +220,8 @@ class FeaturesService:
         logger.info(f"Processing f{original_path}")
         data = json.loads(fileObj.read())
 
-        lng = data.get('geolocation')[0].get('longitude')
-        lat = data.get('geolocation')[0].get('latitude')
-        point = Point(lng, lat)
+        location = parse_rapid_geolocation(data.get('geolocation'))
+        point = Point(location.longitude, location.latitude)
         feat = Feature()
         feat.project_id = projectId
         feat.the_geom = from_shape(point, srid=4326)
@@ -256,7 +257,7 @@ class FeaturesService:
                 # gather coordinates information for this asset
                 logger.debug(f"{asset_file_obj.filename} has the geospatial coordinates of {processed_asset_image.coordinates}")
                 additional_files_properties.append({"filename": base_filename,
-                                                    "coordinates": processed_asset_image.coordinates})
+                                                    "coordinates": (processed_asset_image.coordinates.longitude, processed_asset_image.coordinates.latitude)})
                 asset_file_obj.close()
 
         if additional_files_properties:
@@ -330,10 +331,10 @@ class FeaturesService:
 
     @staticmethod
     def fromFileObj(database_session, projectId: int, fileObj: IO,
-                    metadata: Dict, original_path: str = None, additional_files=None) -> List[Feature]:
+                    metadata: Dict, original_path: str = None, additional_files=None, location: GeoLocation = None) -> List[Feature]:
         ext = pathlib.Path(fileObj.filename).suffix.lstrip(".").lower()
         if ext in features_util.IMAGE_FILE_EXTENSIONS:
-            return [FeaturesService.fromImage(database_session, projectId, fileObj, metadata, original_path)]
+            return [FeaturesService.fromImage(database_session, projectId, fileObj, metadata, original_path, location)]
         elif ext in features_util.GPX_FILE_EXTENSIONS:
             return [FeaturesService.fromGPX(database_session, projectId, fileObj, metadata, original_path)]
         elif ext in features_util.GEOJSON_FILE_EXTENSIONS:
@@ -348,16 +349,24 @@ class FeaturesService:
             raise ApiException("Filetype not supported for direct upload. Create a feature and attach as an asset?")
 
     @staticmethod
-    def fromImage(database_session, projectId: int, fileObj: IO, metadata: Dict, original_path: str = None) -> Feature:
+    def fromImage(database_session, projectId: int, fileObj: IO, metadata: Dict, original_path: str = None, location: GeoLocation = None) -> Feature:
         """
         Create a Point feature from a georeferenced image
-        :param projectId: int
+
+        :param projectId: id of project
         :param fileObj: file
-        :param metadata: dict
+        :param metadata: dict of metadata information
+        :param original_path: original path of image
+        :param location: optional location to use instead of the files exif
         :return: None
         """
-        imdata = ImageService.processImage(fileObj)
-        point = Point(imdata.coordinates)
+        try:
+            logger.debug(f"processing image {original_path} known_geolocation:{location} using_exif_geolocation:{location is None}")
+            imdata = ImageService.processImage(fileObj, exif_geolocation=location is None)
+            coordinates = location if location else imdata.coordinates
+        except InvalidEXIFData:
+            raise InvalidCoordinateReferenceSystem
+        point = Point(coordinates.longitude, coordinates.latitude)
         f = Feature()
         f.project_id = projectId
         f.the_geom = from_shape(point, srid=4326)

--- a/geoapi/services/images.py
+++ b/geoapi/services/images.py
@@ -6,11 +6,12 @@ from PIL import Image
 from PIL.Image import Image as PILImage
 import exifread
 
-from typing import Tuple, IO, AnyStr
+from typing import IO, AnyStr
 from dataclasses import dataclass
 from geoapi.exceptions import InvalidEXIFData
 from geoapi.log import logger
 from geoapi.utils.geo_location import GeoLocation
+
 
 @dataclass
 class ImageData:

--- a/geoapi/services/images.py
+++ b/geoapi/services/images.py
@@ -10,13 +10,13 @@ from typing import Tuple, IO, AnyStr
 from dataclasses import dataclass
 from geoapi.exceptions import InvalidEXIFData
 from geoapi.log import logger
-
+from geoapi.utils.geo_location import GeoLocation
 
 @dataclass
 class ImageData:
     thumb: PILImage
     resized: PILImage
-    coordinates: Tuple[float, float]
+    coordinates: GeoLocation
 
 
 @dataclass
@@ -41,19 +41,23 @@ class ImageService:
         return imdata
 
     @staticmethod
-    def processImage(fileObj: IO) -> ImageData:
+    def processImage(fileObj: IO, exif_geolocation: bool = True) -> ImageData:
         """
-        Resize and get the EXIF GeoLocation from an image
+        Resize and possibly attempt to get the EXIF GeoLocation from an image
 
-        Image need geolocation information. If missing, then
-        get_exif_location raises InvalidEXIFData.
+        Image needs exif embedded geolocation information if `exif_geolocation` is true. If the
+        location is missing when 'exif_geolocation' is true, then InvalidEXIFData is raised
 
         :param fileObj:
+        :param exif_geolocation: if exif data should be read to get image coordinates
         :return:
         """
         imdata = ImageService.resizeImage(fileObj)
-        exif_loc = get_exif_location(fileObj)
-        imdata.coordinates = exif_loc
+        if exif_geolocation:
+            logger.debug("Getting exif geolocation")
+            imdata.coordinates = get_exif_location(fileObj)
+        else:
+            imdata.coordinates = None
         return imdata
 
     @staticmethod
@@ -147,7 +151,7 @@ def _convert_to_degress(value):
     return d + (m / 60.0) + (s / 3600.0)
 
 
-def get_exif_location(image):
+def get_exif_location(image) -> GeoLocation:
     """
     Returns the latitude and longitude, if available, from the provided exif_data (obtained through get_exif_data above)
 
@@ -174,4 +178,4 @@ def get_exif_location(image):
 
     if not lat or not lon:
         raise InvalidEXIFData
-    return lon, lat
+    return GeoLocation(longitude=lon, latitude=lat)

--- a/geoapi/tests/api_tests/test_feature_service.py
+++ b/geoapi/tests/api_tests/test_feature_service.py
@@ -5,10 +5,11 @@ from geoapi.db import db_session
 from geoapi.services.features import FeaturesService
 from geoapi.models import Feature, FeatureAsset, TileServer
 from geoapi.utils.assets import get_project_asset_dir, get_asset_path
+from geoapi.utils.geo_location import GeoLocation
 
 
 def test_create_feature_fromLatLng(projects_fixture):
-    feature = FeaturesService.fromLatLng(db_session, projects_fixture.id, 10, 20, metadata={})
+    feature = FeaturesService.fromLatLng(db_session, projects_fixture.id, GeoLocation(latitude=10, longitude=20), metadata={})
     assert len(feature.assets) == 0
     assert feature.id is not None
 

--- a/geoapi/tests/conftest.py
+++ b/geoapi/tests/conftest.py
@@ -495,3 +495,17 @@ def questionnaire_file_with_assets_fixture():
     with open(os.path.join(home, filename), 'rb') as f:
         f.filename = filename
         yield f
+
+
+@pytest.fixture(scope="function")
+def tapis_metadata_with_geolocation():
+    home = os.path.dirname(__file__)
+    with open(os.path.join(home, 'fixtures/tapis_meta_with_geolocation.json'), 'rb') as f:
+        yield json.loads(f.read())
+
+
+@pytest.fixture(scope="function")
+def tapis_metadata_without_geolocation():
+    home = os.path.dirname(__file__)
+    with open(os.path.join(home, 'fixtures/tapis_meta_no_geolocation.json'), 'rb') as f:
+        yield json.loads(f.read())

--- a/geoapi/tests/external_data_tests/test_external_data.py
+++ b/geoapi/tests/external_data_tests/test_external_data.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 import pytest
 import os
-
+import re
 
 from geoapi.models import User, Feature, ImportedFile
 from geoapi.db import db_session, create_task_session
@@ -103,7 +103,7 @@ def agave_utils_with_bad_image_file(image_file_no_location_fixture):
 
 
 @pytest.fixture(scope="function")
-def agave_utils_with_image_file_from_rapp_folder(image_file_fixture):
+def agave_utils_with_image_file_from_rapp_folder(requests_mock, image_file_fixture):
     filesListing = [
         AgaveFileListing({
             "system": "testSystem",
@@ -124,19 +124,27 @@ def agave_utils_with_image_file_from_rapp_folder(image_file_fixture):
             "lastModified": "2020-08-31T12:00:00Z"
         })
     ]
-    with patch('geoapi.utils.agave.AgaveUtils') as MockAgaveUtilsInUtils:
-        MockAgaveUtilsInUtils().listing.return_value = filesListing
-        MockAgaveUtilsInUtils().getFile.return_value = image_file_fixture
-        MockAgaveUtilsInUtils().getMetaAssociated.return_value = {"geolocation": [{"longitude": 20, "latitude": 30}]}
-        with patch('geoapi.tasks.external_data.AgaveUtils') as MockAgaveUtils:
-            MockAgaveUtils().listing.return_value = filesListing
-            MockAgaveUtils().getFile.return_value = image_file_fixture
-            MockAgaveUtils().getMetaAssociated.return_value = {"geolocation": [{"longitude": 20, "latitude": 30}]}
 
-            class MockAgave:
-                client_in_utils = MockAgaveUtilsInUtils()
-                client_in_external_data = MockAgaveUtils()
-            yield MockAgave
+    METADATA_ROUTE = re.compile(r'http://.*/meta/v2/data')
+    response = {"result": [{"value": {"geolocation": [{"longitude": 20, "latitude": 30}]}}]}
+    requests_mock.get(METADATA_ROUTE, json=response)
+
+    with patch('geoapi.utils.agave.AgaveUtils.listing') as mock_listing_utils, \
+            patch('geoapi.utils.agave.AgaveUtils.getFile') as mock_get_file_utils, \
+            patch('geoapi.tasks.external_data.AgaveUtils.listing') as mock_listing_external_data, \
+            patch('geoapi.tasks.external_data.AgaveUtils.getFile') as mock_get_file_external_data:
+        mock_listing_utils.return_value = filesListing
+        mock_get_file_utils.return_value = image_file_fixture
+        mock_listing_external_data.return_value = filesListing
+        mock_get_file_external_data.return_value = image_file_fixture
+
+        class MockAgave:
+            listing_utils = mock_listing_utils
+            get_file_utils = mock_get_file_utils
+            listing_external_data = mock_listing_external_data
+            get_file_external_data = mock_get_file_external_data
+
+        yield MockAgave
 
 
 @pytest.fixture(scope="function")
@@ -202,7 +210,11 @@ def agave_utils_listing_with_single_trash_folder_of_image(image_file_fixture):
 
 
 @pytest.mark.worker
-def test_external_data_good_files(userdata, projects_fixture, agave_utils_with_geojson_file):
+def test_external_data_good_files(requests_mock, userdata, projects_fixture, agave_utils_with_geojson_file):
+    METADATA_ROUTE = re.compile(r'http://.*/meta/v2/data')
+    response = {"result": [{"value": {"geolocation": [{"longitude": 20, "latitude": 30}]}}]}
+    requests_mock.get(METADATA_ROUTE, json=response)
+
     u1 = db_session.query(User).filter(User.username == "test1").first()
 
     import_from_agave(projects_fixture.tenant_id, u1.id, "testSystem", "/testPath", projects_fixture.id)
@@ -226,7 +238,11 @@ def test_external_data_good_files(userdata, projects_fixture, agave_utils_with_g
 
 
 @pytest.mark.worker
-def test_external_data_bad_files(userdata, projects_fixture, agave_utils_with_bad_image_file):
+def test_external_data_bad_files(requests_mock, userdata, projects_fixture, agave_utils_with_bad_image_file):
+    METADATA_ROUTE = re.compile(r'http://.*/meta/v2/data')
+    response = {"result": [{"value": {"geolocation": [{"longitude": 20, "latitude": 30}]}}]}
+    requests_mock.get(METADATA_ROUTE, json=response)
+
     u1 = db_session.query(User).filter(User.username == "test1").first()
 
     import_from_agave(projects_fixture.tenant_id, u1.id, "testSystem", "/testPath", projects_fixture.id)
@@ -273,12 +289,16 @@ def test_external_data_rapp(userdata, projects_fixture,
     assert len(features[0].assets) == 1
     assert len(os.listdir(get_project_asset_dir(features[0].project_id))) == 2  # processed image + thumbnail
     # This should only have been called once, since there is only one FILE in the listing
-    agave_utils_with_image_file_from_rapp_folder.client_in_external_data.getFile.assert_called_once()
+    agave_utils_with_image_file_from_rapp_folder.get_file_external_data.assert_called_once()
 
 
 @pytest.mark.worker
-def test_external_data_rapp_missing_geospatial_metadata(userdata, projects_fixture, agave_utils_with_image_file_from_rapp_folder):
-    agave_utils_with_image_file_from_rapp_folder.client_in_utils.getMetaAssociated.return_value = {}
+def test_external_data_rapp_missing_geospatial_metadata(userdata, projects_fixture,
+                                                        agave_utils_with_image_file_from_rapp_folder, requests_mock):
+    METADATA_ROUTE = re.compile(r'http://.*/meta/v2/data')
+    response = {"result": [{"value": {"geolocation": []}}]}
+    requests_mock.get(METADATA_ROUTE, json=response)
+
     u1 = db_session.query(User).filter(User.username == "test1").first()
     import_from_agave(projects_fixture.tenant_id, u1.id, "testSystem", "/Rapp", projects_fixture.id)
     features = db_session.query(Feature).all()

--- a/geoapi/tests/fixtures/tapis_meta_no_geolocation.json
+++ b/geoapi/tests/fixtures/tapis_meta_no_geolocation.json
@@ -1,0 +1,53 @@
+{
+  "result": [
+    {
+      "uuid": "8979750356237676050-242ac117-0001-012",
+      "owner": "ds_admin",
+      "schemaId": null,
+      "internalUsername": null,
+      "associationIds": [],
+      "lastUpdated": "2024-01-16T17:11:00.585-06:00",
+      "name": "designsafe.file",
+      "value": {
+        "_author": "Test User",
+        "geolocation": [],
+        "instrument_manufacturer_and_model": "",
+        "title": "Photo 1688148916614",
+        "_timestamp": 1688148922.1698608,
+        "_rapp_parent_collection_uuid": "F45CD6A6-4DC0-42CE-A717-16045AF5F6A7",
+        "geoid_model": "",
+        "misc_notes": "",
+        "instrument_type": "other",
+        "coord_system_epoch": "",
+        "path": "/test_user/Photo1.jpg",
+        "system": "project-4193535358505521646-242ac117-0001-012",
+        "geodetic_datum": "",
+        "coord_ref_system": "",
+        "geodetic_datum_realization": "",
+        "basePath": "/test_user",
+        "vertical_datum": "",
+        "format": "jpg",
+        "_rapp_asset_uuid": "B28E06C3-9B14-4235-B307-2F0F5FA961C0",
+        "units": "",
+        "data_type": "image",
+        "referenced_data_links": [],
+        "coord_system": "",
+        "data_hazard_type": "other",
+        "description": ""
+      },
+      "created": "2024-01-16T17:11:00.585-06:00",
+      "_links": {
+        "self": {
+          "href": "https://agave.designsafe-ci.org/meta/v2/data/8979750356237676050-242ac117-0001-012"
+        },
+        "permissions": {
+          "href": "https://agave.designsafe-ci.org/meta/v2/data/8979750356237676050-242ac117-0001-012/pems"
+        },
+        "owner": {
+          "href": "https://agave.designsafe-ci.org/profiles/v2/ds_admin"
+        },
+        "associationIds": []
+      }
+    }
+  ]
+}

--- a/geoapi/tests/fixtures/tapis_meta_with_geolocation.json
+++ b/geoapi/tests/fixtures/tapis_meta_with_geolocation.json
@@ -1,0 +1,62 @@
+{
+  "result": [
+    {
+      "uuid": "8846490921293573650-242ac117-0001-012",
+      "owner": "ds_admin",
+      "schemaId": null,
+      "internalUsername": null,
+      "associationIds": [],
+      "lastUpdated": "2024-01-20T07:05:01.333-06:00",
+      "name": "designsafe.file",
+      "value": {
+        "_author": "Test User",
+        "geolocation": [
+          {
+            "longitude": -122.30701480072206,
+            "timestamp": 1690399239.996102,
+            "latitude": 47.65349416532335,
+            "course": 305.5078125,
+            "heading": 318.62109375,
+            "altitude": 37.63900375366211
+          }
+        ],
+        "instrument_manufacturer_and_model": "",
+        "title": "Photo 1690399237478",
+        "_timestamp": 1690399240.36766,
+        "_rapp_parent_collection_uuid": "CA16655D-A422-444D-A078-546BC5CF1C67",
+        "geoid_model": "",
+        "misc_notes": "",
+        "instrument_type": "other",
+        "coord_system_epoch": "",
+        "path": "/Photo 1690399237478.jpg",
+        "system": "project-4193535358505521646-242ac117-0001-012",
+        "geodetic_datum": "",
+        "coord_ref_system": "",
+        "geodetic_datum_realization": "",
+        "basePath": "/",
+        "vertical_datum": "",
+        "format": "jpg",
+        "_rapp_asset_uuid": "8C9E6B10-0A00-4F0B-BDD8-E443BDE64519",
+        "units": "",
+        "data_type": "image",
+        "referenced_data_links": [],
+        "coord_system": "",
+        "data_hazard_type": "other",
+        "description": ""
+      },
+      "created": "2024-01-20T07:05:01.333-06:00",
+      "_links": {
+        "self": {
+          "href": "https://agave.designsafe-ci.org/meta/v2/data/8846490921293573650-242ac117-0001-012"
+        },
+        "permissions": {
+          "href": "https://agave.designsafe-ci.org/meta/v2/data/8846490921293573650-242ac117-0001-012/pems"
+        },
+        "owner": {
+          "href": "https://agave.designsafe-ci.org/profiles/v2/ds_admin"
+        },
+        "associationIds": []
+      }
+    }
+  ]
+}

--- a/geoapi/tests/services/test_image_service.py
+++ b/geoapi/tests/services/test_image_service.py
@@ -1,6 +1,7 @@
 from geoapi.services.images import ImageService, get_exif_location
 from geoapi.exceptions import InvalidEXIFData
 from PIL import Image, ImageChops
+from geoapi.utils.geo_location import GeoLocation
 import pytest
 
 
@@ -21,13 +22,13 @@ def test_image_service_rotations(flipped_image_fixture, corrected_image_fixture)
     # check lat long
     true_long = -81.64792777777778
     true_lat = 24.596927777777776
-    assert imdata.coordinates[0] - true_long < 0.0001
-    assert imdata.coordinates[1] - true_lat < 0.0001
+    assert imdata.coordinates.longitude - true_long < 0.0001
+    assert imdata.coordinates.latitude - true_lat < 0.0001
 
 
 def test_get_exif_location(image_file_fixture):
     coordinates = get_exif_location(image_file_fixture)
-    assert coordinates == (-80.78037499999999, 32.61850555555556)
+    assert coordinates == GeoLocation(longitude=-80.78037499999999, latitude=32.61850555555556)
 
 
 def test_get_exif_location_missing(image_file_no_location_fixture):
@@ -37,9 +38,12 @@ def test_get_exif_location_missing(image_file_no_location_fixture):
 
 def test_process_image(image_file_fixture):
     imdata = ImageService.processImage(image_file_fixture)
-    assert imdata.coordinates == (-80.78037499999999, 32.61850555555556)
+    assert imdata.coordinates == GeoLocation(longitude=-80.78037499999999, latitude=32.61850555555556)
 
 
 def test_process_image_location_missing(image_file_no_location_fixture):
     with pytest.raises(InvalidEXIFData):
         ImageService.processImage(image_file_no_location_fixture)
+
+    imdata = ImageService.processImage(image_file_no_location_fixture, exif_geolocation=False)
+    assert imdata.coordinates is None

--- a/geoapi/tests/utils_tests/test_geo_location.py
+++ b/geoapi/tests/utils_tests/test_geo_location.py
@@ -1,0 +1,29 @@
+from geoapi.utils.geo_location import get_geolocation_from_file_metadata, GeoLocation
+import re
+
+METADATA_ROUTE = re.compile(r'http://.*/meta/v2/data')
+SYSTEM = "SYSTEM"
+PATH = "PATH"
+
+
+def test_no_metadata(requests_mock, user1):
+    response = {"result": [{}]}
+    requests_mock.get(METADATA_ROUTE, json=response)
+    assert get_geolocation_from_file_metadata(user1, system_id=SYSTEM, path=PATH) is None
+
+    response = {"result": []}
+    requests_mock.get(METADATA_ROUTE, json=response)
+    assert get_geolocation_from_file_metadata(user1, system_id=SYSTEM, path=PATH) is None
+
+
+def test_metadata_but_no_geolocation(requests_mock, user1, tapis_metadata_without_geolocation):
+    requests_mock.get(METADATA_ROUTE, json=tapis_metadata_without_geolocation)
+
+    assert get_geolocation_from_file_metadata(user1, system_id=SYSTEM, path=PATH) is None
+
+
+def test_metadata_with_geolocation(requests_mock, user1, tapis_metadata_with_geolocation):
+    requests_mock.get(METADATA_ROUTE, json=tapis_metadata_with_geolocation)
+
+    assert (get_geolocation_from_file_metadata(user1, system_id=SYSTEM, path=PATH) ==
+            GeoLocation(longitude=-122.30701480072206, latitude=47.65349416532335))

--- a/geoapi/utils/additional_file.py
+++ b/geoapi/utils/additional_file.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class AdditionalFile:
+    """Represents an additional file with its path and if its required (i.e. not optional)."""
+    path: str
+    required: bool

--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -356,6 +356,6 @@ def get_metadata_using_service_account(tenant_id: str, system_id: str, path: str
     # same as Tapis v2 python client's: client.meta.listMetadata(q=json.dumps(query), limit=300, offset=0)
     response = client.get(url=quote('/meta/v2/data/'), params=params)
     meta_list = response.json()["result"]
-    if len(meta_list) > 0:
+    if len(meta_list) > 0 and "value" in meta_list[0]:
         return meta_list[0]["value"]
     return {}

--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -355,6 +355,7 @@ def get_metadata_using_service_account(tenant_id: str, system_id: str, path: str
 
     # same as Tapis v2 python client's: client.meta.listMetadata(q=json.dumps(query), limit=300, offset=0)
     response = client.get(url=quote('/meta/v2/data/'), params=params)
+    response.raise_for_status()
     meta_list = response.json()["result"]
     if len(meta_list) > 0 and "value" in meta_list[0]:
         return meta_list[0]["value"]

--- a/geoapi/utils/features.py
+++ b/geoapi/utils/features.py
@@ -72,7 +72,9 @@ def is_file_supported_for_automatic_scraping(path):
 
 def is_supported_for_automatic_scraping_without_metadata(path):
     """
-    Check to see if file is supported for automatic importing (without metadata).
+    Check to see if file is supported for automatic importing (without required metadata*).
+
+    Asset doesn't require metadata but could use it if available.
 
     Note: assets like images inside the questionnaire archive (i.e in .rqa) should be ignored. Only the
     .rq file inside a .rqa file should be imported.

--- a/geoapi/utils/geo_location.py
+++ b/geoapi/utils/geo_location.py
@@ -30,7 +30,6 @@ def get_geolocation_from_file_metadata(user: User, system_id: str, path: str) ->
     :return: A GeoLocation object if geolocation information is found; otherwise, None.
     """
     meta = get_metadata_using_service_account(user.tenant_id, system_id, path)
-    if meta and "geolocation" in meta and len(meta["geolocation"]) > 1:
+    if meta and "geolocation" in meta and len(meta["geolocation"]) > 0:
         return parse_rapid_geolocation(meta.get("geolocation"))
-
     return None

--- a/geoapi/utils/geo_location.py
+++ b/geoapi/utils/geo_location.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from geoapi.utils.agave import get_metadata_using_service_account
+from geoapi.models import User
+from typing import Optional
+
+from geoapi.log import logger
+
+
+@dataclass
+class GeoLocation:
+    """ Represents a geographical location with latitude and longitude."""
+    latitude: float
+    longitude: float
+
+
+def parse_rapid_geolocation(geolocation_metadata):
+    first_coordinates = geolocation_metadata[0]
+    lat = first_coordinates["latitude"]
+    lon = first_coordinates["longitude"]
+    return GeoLocation(lat, lon)
+
+
+def get_geolocation_from_file_metadata(user: User, system_id: str, path: str) -> Optional[GeoLocation]:
+    """
+    Retrieves the geolocation from Tapis file metadata.
+
+    This function attempts to extract geolocation information from the metadata of a file.
+    If the metadata does not exist or does not contain geolocation information, None is returned.
+
+    Note: This metadata is typically written by the Rapp application.
+
+    :return: A GeoLocation object if geolocation information is found; otherwise, None.
+    """
+    meta = get_metadata_using_service_account(user.tenant_id, system_id, path)
+    if meta and "geolocation" in meta and len(meta["geolocation"]) > 1:
+        return parse_rapid_geolocation(meta.get("geolocation"))
+
+    return None

--- a/geoapi/utils/geo_location.py
+++ b/geoapi/utils/geo_location.py
@@ -3,8 +3,6 @@ from geoapi.utils.agave import get_metadata_using_service_account
 from geoapi.models import User
 from typing import Optional
 
-from geoapi.log import logger
-
 
 @dataclass
 class GeoLocation:


### PR DESCRIPTION
## Overview: ##

This PR:
* addresses WG-211/DES-2636 by searching by file name to get tapis file metadata. This mimics how DS gets tapis file metadata.  All changes for this are in `geoapi/utils/agave.py`
* uses tapis file metadata created by RApp during file image imports (WG-39). Previously, this was only done when scraping files and if the field were within the the Rapp subfolder. Now users can manually import files using metadata and they no longer have to be located in the Rapp subfolder for tapis-metadata to be used.

All changes in this PR (besides those in  `geoapi/utils/agave.py`) are related to bullet point 2.  With these changes, now we get tapis metadata on all images being imported and use the location information there if it exists.  Otherwise, we use the image file's exif data.


## Related Jira tickets: ##

* [WG-211](https://tacc-main.atlassian.net/browse/WG-211)
* [WG-39](https://tacc-main.atlassian.net/browse/WG-39)

## Testing Steps: ##
1. Everyone has been added to https://www.designsafe-ci.org/data/browser/projects/4193535358505521646-242ac117-0001-012/ (i.e. PRJ-4530 | TEST_WG_211_metadata)
2. Create a generic map and then manually select files and try importing (i.e. on Map, click Assets and then "Import from DesignSafe") . Watch geoapi logs.
3. Delete previous map
3. Create another map and this time scrape (check "Sync Folder" button in create map modal) and link to the `PRJ-4530 | TEST_WG_211_metadata` (via "Select Link Save Location) -  https://www.designsafe-ci.org/data/browser/projects/4193535358505521646-242ac117-0001-012/ (i.e. ). Watch geoapi logs.

Let me know if you need more data to test.
