### PR TITLE
Hotfix/fix watchtower

### DIFF
--- a/devops/geoapi-services/docker-compose.yml
+++ b/devops/geoapi-services/docker-compose.yml
@@ -113,7 +113,7 @@ services:
     image: containrrr/watchtower:1.7.1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: --interval 300 api celerybeat hazmapper hazmapper-react taggit
+    command: --interval 300 geoapi geoapicelerybeat hazmapper hazmapper-react taggit
     # Watchtower configuration for development environment. This service monitors
     # and updates the specified containers every 5 min (300s). Staging/Production
     # use specific commit hash tags, so updates are controlled and do not affect

--- a/devops/geoapi-workers/docker-compose.yml
+++ b/devops/geoapi-workers/docker-compose.yml
@@ -20,3 +20,15 @@ services:
       options:
         tag: geoapi_workers
     command: "celery -A geoapi.celery_app worker -l info"
+
+  watchtower:
+    image: containrrr/watchtower:1.7.1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 300 geoapiworkers
+    # Watchtower configuration for development environment. This service monitors
+    # and updates the specified containers every 5 min (300s). Staging/Production
+    # use specific commit hash tags, so updates are controlled and do not affect
+    # those environments. In Development, 'latest' tags are used, enabling
+    # Watchtower to automatically update these containers.
+    restart: always


### PR DESCRIPTION
## Overview: ##

I noticed that watchtower (added [here](https://github.com/TACC-Cloud/geoapi/pull/171)) wasn't working correctly for backend services due using the wrong names for the services. This PR
* fixes the naming issues for geoapi-related services (geoapi and celerybeat)
* adds watchtower to worker's docker-compose