### PR TITLE
task/WG-254: use file-metadata routes from DesignSafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ Note that images need to be rebuilt before running tests if they have been updat
 ```
 make build
 ```
+
+or run directly in your running containers:
+```
+docker exec -it geoapi_postgres psql -d postgres  -U dev
+CREATE DATABASE TEST;
+ \connect test;
+CREATE EXTENSION postgis;
+
+# then run tests in api
+docker exec -it geoapi bash
+APP_ENV=testing pytest
+
+# then run tests in worker
+docker exec -it geoapiworkers bash
+APP_ENV=testing pytest -m "worker"
+```
+
+
 ## Kubernetes (Production/Staging)
 
 Information on Kubernetes configuration for production and staging environments can be found in the [kube/README.md](kube/README.md) including information

--- a/devops/docker-compose.local.yml
+++ b/devops/docker-compose.local.yml
@@ -55,7 +55,6 @@ services:
       - FLASK_APP=/app/geoapi/app.py
       - APP_ENV=local
       - ASSETS_BASE_DIR=/assets
-      - TENANT=${TENANT_TAPIS_V3}
       - DESIGNSAFE_URL=${DESIGNSAFE_URL}
 
     stdin_open: true
@@ -99,7 +98,6 @@ services:
       - FLASK_APP=/app/geoapi/app.py
       - APP_ENV=local
       - ASSETS_BASE_DIR=/assets
-      - TENANT=${TENANT_TAPIS_V3}
       - DESIGNSAFE_URL=${DESIGNSAFE_URL}
     stdin_open: true
     tty: true

--- a/devops/docker-compose.local.yml
+++ b/devops/docker-compose.local.yml
@@ -56,6 +56,7 @@ services:
       - APP_ENV=local
       - ASSETS_BASE_DIR=/assets
       - TENANT=${TENANT_TAPIS_V3}
+      - DESIGNSAFE_URL=${DESIGNSAFE_URL}
 
     stdin_open: true
     tty: true
@@ -99,6 +100,7 @@ services:
       - APP_ENV=local
       - ASSETS_BASE_DIR=/assets
       - TENANT=${TENANT_TAPIS_V3}
+      - DESIGNSAFE_URL=${DESIGNSAFE_URL}
     stdin_open: true
     tty: true
     container_name: geoapi

--- a/devops/docker-compose.local.yml
+++ b/devops/docker-compose.local.yml
@@ -55,7 +55,8 @@ services:
       - FLASK_APP=/app/geoapi/app.py
       - APP_ENV=local
       - ASSETS_BASE_DIR=/assets
-      - TENANT=${TENANT}
+      - TENANT=${TENANT_TAPIS_V3}
+
     stdin_open: true
     tty: true
     container_name: geoapiworkers
@@ -97,7 +98,7 @@ services:
       - FLASK_APP=/app/geoapi/app.py
       - APP_ENV=local
       - ASSETS_BASE_DIR=/assets
-      - TENANT=${TENANT}
+      - TENANT=${TENANT_TAPIS_V3}
     stdin_open: true
     tty: true
     container_name: geoapi

--- a/devops/geoapi-services/docker-compose.yml
+++ b/devops/geoapi-services/docker-compose.yml
@@ -75,6 +75,8 @@ services:
       - FLASK_APP=/app/geoapi/app.py
       - ASSETS_BASE_DIR=/assets
       - GEOAPI_TAG=ENV_GEOAPI_TAG
+      - TENANT=${TENANT_TAPIS_V3}
+      - DESIGNSAFE_URL=${DESIGNSAFE_URL}
     stdin_open: true
     tty: true
     container_name: geoapi

--- a/devops/geoapi-services/docker-compose.yml
+++ b/devops/geoapi-services/docker-compose.yml
@@ -75,7 +75,6 @@ services:
       - FLASK_APP=/app/geoapi/app.py
       - ASSETS_BASE_DIR=/assets
       - GEOAPI_TAG=ENV_GEOAPI_TAG
-      - TENANT=${TENANT_TAPIS_V3}
       - DESIGNSAFE_URL=${DESIGNSAFE_URL}
     stdin_open: true
     tty: true

--- a/devops/geoapi-workers/docker-compose.yml
+++ b/devops/geoapi-workers/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - FLASK_APP=/app/geoapi/app.py
       - ASSETS_BASE_DIR=/assets
       - GEOAPI_TAG=ENV_GEOAPI_TAG
+      - TENANT=${TENANT_TAPIS_V3}
+      - DESIGNSAFE_URL=${DESIGNSAFE_URL}
     stdin_open: true
     tty: true
     container_name: geoapiworkers

--- a/devops/geoapi-workers/docker-compose.yml
+++ b/devops/geoapi-workers/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - FLASK_APP=/app/geoapi/app.py
       - ASSETS_BASE_DIR=/assets
       - GEOAPI_TAG=ENV_GEOAPI_TAG
-      - TENANT=${TENANT_TAPIS_V3}
       - DESIGNSAFE_URL=${DESIGNSAFE_URL}
     stdin_open: true
     tty: true

--- a/geoapi/custom/designsafe/project.py
+++ b/geoapi/custom/designsafe/project.py
@@ -1,12 +1,11 @@
 import json
 import os
 from geoapi.log import logger
+from geoapi.settings import settings
 from geoapi.custom.designsafe.default_basemap_layers import default_layers
 from geoapi.models import User, Project
 
 import requests
-
-DESIGNSAFE_URL = 'https://www.designsafe-ci.org/'  # 'https://designsafeci-dev.tacc.utexas.edu/';
 
 
 def on_project_creation(database_session, user: User, project: Project):
@@ -85,7 +84,7 @@ def update_designsafe_project_hazmapper_metadata(user: User, project: Project, a
     client = requests.Session()
     client.headers.update({'X-JWT-Assertion-designsafe': user.jwt})
 
-    response = client.get(DESIGNSAFE_URL + f"api/projects/{designsafe_uuid}/")
+    response = client.get(settings.DESIGNSAFE_URL + f"api/projects/{designsafe_uuid}/")
     response.raise_for_status()
 
     current_metadata = response.json()
@@ -102,7 +101,7 @@ def update_designsafe_project_hazmapper_metadata(user: User, project: Project, a
                          "deployment": os.getenv("APP_ENV")}
         all_maps.append(new_map_entry)
     logger.debug(f"Updated metadata for DesignSafe_project:{designsafe_uuid}: {all_maps}")
-    response = client.post(DESIGNSAFE_URL + f"api/projects/{designsafe_uuid}/",
+    response = client.post(settings.DESIGNSAFE_URL + f"api/projects/{designsafe_uuid}/",
                            json={"hazmapperMaps": all_maps},
                            headers={'X-Requested-With': 'XMLHttpRequest'})
     response.raise_for_status()

--- a/geoapi/custom/designsafe/project.py
+++ b/geoapi/custom/designsafe/project.py
@@ -84,7 +84,7 @@ def update_designsafe_project_hazmapper_metadata(user: User, project: Project, a
     client = requests.Session()
     client.headers.update({'X-JWT-Assertion-designsafe': user.jwt})
 
-    response = client.get(settings.DESIGNSAFE_URL + f"api/projects/{designsafe_uuid}/")
+    response = client.get(settings.DESIGNSAFE_URL + f"/api/projects/{designsafe_uuid}/")
     response.raise_for_status()
 
     current_metadata = response.json()
@@ -101,7 +101,7 @@ def update_designsafe_project_hazmapper_metadata(user: User, project: Project, a
                          "deployment": os.getenv("APP_ENV")}
         all_maps.append(new_map_entry)
     logger.debug(f"Updated metadata for DesignSafe_project:{designsafe_uuid}: {all_maps}")
-    response = client.post(settings.DESIGNSAFE_URL + f"api/projects/{designsafe_uuid}/",
+    response = client.post(settings.DESIGNSAFE_URL + f"/api/projects/{designsafe_uuid}/",
                            json={"hazmapperMaps": all_maps},
                            headers={'X-Requested-With': 'XMLHttpRequest'})
     response.raise_for_status()

--- a/geoapi/exceptions.py
+++ b/geoapi/exceptions.py
@@ -19,11 +19,6 @@ class ObservableProjectAlreadyExists(Exception):
     pass
 
 
-class MissingServiceAccount(Exception):
-    """ No service account for this tenant """
-    pass
-
-
 class ApiException(Exception):
     """ A generic exception from the api"""
     pass

--- a/geoapi/settings.py
+++ b/geoapi/settings.py
@@ -9,6 +9,7 @@ class Config(object):
     RESTPLUS_MASK_SWAGGER = False
     TENANT = os.environ.get("TENANT")
     STREETVIEW_DIR = os.environ.get('STREETVIEW_DIR', '/assets/streetview')
+    DESIGNSAFE_URL = os.environ.get("DESIGNSAFE_URL")
 
 
 class DeployedConfig(Config):

--- a/geoapi/settings.py
+++ b/geoapi/settings.py
@@ -47,6 +47,7 @@ class UnitTestingConfig(LocalDevelopmentConfig):
     ASSETS_BASE_DIR = '/tmp'
     TENANT = "{\"DESIGNSAFE\": {\"tg458981_service_account_token\": \"ABCDEFG12344\"}," \
              " \"TEST\": {\"tg458981_service_account_token\": \"ABCDEFG12344\"}  }"
+    DESIGNSAFE_URL = os.environ.get("DESIGNSAFE_URL", "https://designsafe-not-real.tacc.utexas.edu")
 
 
 APP_ENV = os.environ.get('APP_ENV', '').lower()

--- a/geoapi/settings.py
+++ b/geoapi/settings.py
@@ -44,8 +44,8 @@ class UnitTestingConfig(LocalDevelopmentConfig):
     TESTING = True
     STREETVIEW_DIR = os.environ.get('STREETVIEW_DIR', '/tmp/streetview')
     ASSETS_BASE_DIR = '/tmp'
-    TENANT = "{\"DESIGNSAFE\": {\"service_account_token\": \"ABCDEFG12344\"}," \
-             " \"TEST\": {\"service_account_token\": \"ABCDEFG12344\"}  }"
+    TENANT = "{\"DESIGNSAFE\": {\"tg458981_service_account_token\": \"ABCDEFG12344\"}," \
+             " \"TEST\": {\"tg458981_service_account_token\": \"ABCDEFG12344\"}  }"
 
 
 APP_ENV = os.environ.get('APP_ENV', '').lower()

--- a/geoapi/settings.py
+++ b/geoapi/settings.py
@@ -45,8 +45,6 @@ class UnitTestingConfig(LocalDevelopmentConfig):
     TESTING = True
     STREETVIEW_DIR = os.environ.get('STREETVIEW_DIR', '/tmp/streetview')
     ASSETS_BASE_DIR = '/tmp'
-    TENANT = "{\"DESIGNSAFE\": {\"tg458981_service_account_token\": \"ABCDEFG12344\"}," \
-             " \"TEST\": {\"tg458981_service_account_token\": \"ABCDEFG12344\"}  }"
     DESIGNSAFE_URL = os.environ.get("DESIGNSAFE_URL", "https://designsafe-not-real.tacc.utexas.edu")
 
 

--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -9,9 +9,9 @@ from celery import uuid as celery_uuid
 import json
 
 from geoapi.celery_app import app
-from geoapi.exceptions import InvalidCoordinateReferenceSystem, MissingServiceAccount, GetUsersForProjectNotSupported
+from geoapi.exceptions import InvalidCoordinateReferenceSystem, GetUsersForProjectNotSupported
 from geoapi.models import User, ProjectUser, ObservableDataProject, Task
-from geoapi.utils.agave import (AgaveUtils, SystemUser, get_system_users, get_metadata_using_service_account,
+from geoapi.utils.agave import (AgaveUtils, SystemUser, get_system_users, get_metadata,
                                 AgaveFileGetError, AgaveListingError)
 from geoapi.utils import features as features_util
 from geoapi.log import logger
@@ -304,12 +304,7 @@ def import_from_files_from_path(session, tenant_id: str, userId: int, systemId: 
                 # If it is a RApp project folder and not a questionnaire file, use the metadata from tapis meta service
                 if features_util.is_supported_file_type_in_rapp_folder_and_needs_metadata(item_system_path):
                     logger.info(f"RApp: importing:{item_system_path} for user:{user.username}. Using metadata service for geolocation.")
-                    try:
-                        meta = get_metadata_using_service_account(tenant_id, systemId, item.path)
-                    except MissingServiceAccount:
-                        logger.error(
-                            "No service account. Unable to get metadata for {}:{}".format(systemId, item.path))
-                        return {}
+                    meta = get_metadata(user, systemId, item.path)
 
                     logger.debug("metadata from service account for file:{} : {}".format(item_system_path, meta))
 

--- a/geoapi/tests/custom/designsafe/test_project.py
+++ b/geoapi/tests/custom/designsafe/test_project.py
@@ -43,7 +43,7 @@ def test_on_project_deletion(tapis_url, requests_mock, user1, observable_project
 
     designsafe_uuid = project.system_id[len("project-"):]
 
-    metadata_url = settings.DESIGNSAFE_URL + f"api/projects/{designsafe_uuid}/"
+    metadata_url = settings.DESIGNSAFE_URL + f"/api/projects/{designsafe_uuid}/"
     requests_mock.get(metadata_url, json={"value": {"hazmapperMaps": [{"name": project.name,
                                                                        "uuid": str(project.uuid),
                                                                        "path": project.system_path,

--- a/geoapi/tests/custom/designsafe/test_project.py
+++ b/geoapi/tests/custom/designsafe/test_project.py
@@ -14,7 +14,7 @@ def test_on_project_creation(tapis_url, requests_mock, user1, observable_project
 
     designsafe_uuid = project.system_id[len("project-"):]
 
-    metadata_url = settings.DESIGNSAFE_URL + f"api/projects/{designsafe_uuid}/"
+    metadata_url = settings.DESIGNSAFE_URL + f"/api/projects/{designsafe_uuid}/"
     requests_mock.get(metadata_url, json={"value": {"hazmapperMaps": []}})
     requests_mock.post(metadata_url)
 

--- a/geoapi/tests/custom/designsafe/test_project.py
+++ b/geoapi/tests/custom/designsafe/test_project.py
@@ -1,5 +1,6 @@
-from geoapi.custom.designsafe.project import on_project_creation, on_project_deletion, DESIGNSAFE_URL
+from geoapi.custom.designsafe.project import on_project_creation, on_project_deletion
 from geoapi.services.features import FeaturesService
+from geoapi.settings import settings
 from geoapi.db import db_session
 from urllib.parse import quote
 import json
@@ -13,7 +14,7 @@ def test_on_project_creation(tapis_url, requests_mock, user1, observable_project
 
     designsafe_uuid = project.system_id[len("project-"):]
 
-    metadata_url = DESIGNSAFE_URL + f"api/projects/{designsafe_uuid}/"
+    metadata_url = settings.DESIGNSAFE_URL + f"api/projects/{designsafe_uuid}/"
     requests_mock.get(metadata_url, json={"value": {"hazmapperMaps": []}})
     requests_mock.post(metadata_url)
 
@@ -42,7 +43,7 @@ def test_on_project_deletion(tapis_url, requests_mock, user1, observable_project
 
     designsafe_uuid = project.system_id[len("project-"):]
 
-    metadata_url = DESIGNSAFE_URL + f"api/projects/{designsafe_uuid}/"
+    metadata_url = settings.DESIGNSAFE_URL + f"api/projects/{designsafe_uuid}/"
     requests_mock.get(metadata_url, json={"value": {"hazmapperMaps": [{"name": project.name,
                                                                        "uuid": str(project.uuid),
                                                                        "path": project.system_path,

--- a/geoapi/tests/custom/designsafe/test_project_users.py
+++ b/geoapi/tests/custom/designsafe/test_project_users.py
@@ -1,30 +1,31 @@
 import os
 import pytest
+from unittest.mock import patch
 import json
 from geoapi.custom.designsafe.project_users import get_system_users
 
 
 @pytest.fixture()
-def project_response(mocker):
+def project_response():
     home = os.path.dirname(__file__)
     with open(os.path.join(home, '../../fixtures/designsafe_api_project.json'), 'rb') as f:
         mock_data = json.loads(f.read())
 
     # TODO_TAPISV3 https://tacc-main.atlassian.net/browse/WG-257 can be dropped later as we rely on requests_mock
     # in tests
-    with mocker.patch('geoapi.custom.designsafe.project_users.get_project_data', return_value=mock_data["value"]):
+    with patch('geoapi.custom.designsafe.project_users.get_project_data', return_value=mock_data["value"]):
         yield mock_data
 
 
 @pytest.fixture()
-def project_response_with_duplicate_users(mocker):
+def project_response_with_duplicate_users():
     home = os.path.dirname(__file__)
     with open(os.path.join(home, '../../fixtures/designsafe_api_project_with_duplicate_users.json'), 'rb') as f:
         mock_data = json.loads(f.read())
 
     # TODO_TAPISV3 https://tacc-main.atlassian.net/browse/WG-257 can be dropped later as we rely on equests_mock
     # in tests
-    with mocker.patch('geoapi.custom.designsafe.project_users.get_project_data', return_value=mock_data["value"]):
+    with patch('geoapi.custom.designsafe.project_users.get_project_data', return_value=mock_data["value"]):
         yield mock_data["value"]
 
 

--- a/geoapi/tests/external_data_tests/test_external_data.py
+++ b/geoapi/tests/external_data_tests/test_external_data.py
@@ -18,6 +18,7 @@ from geoapi.services.point_cloud import PointCloudService
 
 METADATA_ROUTE = re.compile(r'https://.*/api/filemeta/.*/.*')
 
+
 @pytest.fixture(scope="function")
 def metadata_none_fixture(requests_mock):
     response = {}

--- a/geoapi/tests/external_data_tests/test_external_data.py
+++ b/geoapi/tests/external_data_tests/test_external_data.py
@@ -16,6 +16,26 @@ from geoapi.exceptions import InvalidCoordinateReferenceSystem
 from geoapi.services.point_cloud import PointCloudService
 
 
+METADATA_ROUTE = re.compile(r'https://.*/api/filemeta/.*/.*')
+
+@pytest.fixture(scope="function")
+def metadata_none_fixture(requests_mock):
+    response = {}
+    requests_mock.get(METADATA_ROUTE, json=response)
+
+
+@pytest.fixture(scope="function")
+def metadata_but_no_geolocation_fixture(requests_mock):
+    response = {"value": {"geolocation": []}}
+    requests_mock.get(METADATA_ROUTE, json=response)
+
+
+@pytest.fixture(scope="function")
+def metadata_geolocation_30long_20lat_fixture(requests_mock):
+    response = {"value": {"geolocation": [{"longitude": 20, "latitude": 30}]}}
+    requests_mock.get(METADATA_ROUTE, json=response)
+
+
 @pytest.fixture(scope="function")
 def get_system_users_mock(user1, user2):
     users = [SystemUser(username=user1.username, admin=True), SystemUser(username=user2.username, admin=False)]
@@ -78,7 +98,7 @@ def agave_utils_with_bad_image_file(image_file_no_location_fixture):
 
 
 @pytest.fixture(scope="function")
-def agave_utils_with_image_file_from_rapp_folder(requests_mock, image_file_fixture):
+def agave_utils_with_image_file_from_rapp_folder(metadata_geolocation_30long_20lat_fixture, requests_mock, image_file_fixture):
     filesListing = [
         AgaveFileListing({
             "type": "file",
@@ -86,10 +106,6 @@ def agave_utils_with_image_file_from_rapp_folder(requests_mock, image_file_fixtu
             "lastModified": "2020-08-31T12:00:00Z"
         })
     ]
-
-    METADATA_ROUTE = re.compile(r'http://.*/meta/v2/data')
-    response = {"result": [{"value": {"geolocation": [{"longitude": 20, "latitude": 30}]}}]}
-    requests_mock.get(METADATA_ROUTE, json=response)
 
     with patch('geoapi.utils.agave.AgaveUtils.listing') as mock_listing_utils, \
             patch('geoapi.utils.agave.AgaveUtils.getFile') as mock_get_file_utils, \
@@ -146,11 +162,8 @@ def agave_utils_listing_with_single_trash_folder_of_image(image_file_fixture):
 
 
 @pytest.mark.worker
-def test_external_data_good_files(requests_mock, user1, projects_fixture, agave_utils_with_geojson_file):
-    METADATA_ROUTE = re.compile(r'http://.*/meta/v2/data')
-    response = {"result": [{"value": {"geolocation": [{"longitude": 20, "latitude": 30}]}}]}
-    requests_mock.get(METADATA_ROUTE, json=response)
-
+def test_external_data_good_files(metadata_geolocation_30long_20lat_fixture, user1,
+                                  projects_fixture, agave_utils_with_geojson_file):
     import_from_agave(projects_fixture.tenant_id, user1.id, "testSystem", "/testPath", projects_fixture.id)
     features = db_session.query(Feature).all()
     # the test geojson has 3 features in it
@@ -172,11 +185,7 @@ def test_external_data_good_files(requests_mock, user1, projects_fixture, agave_
 
 
 @pytest.mark.worker
-def test_external_data_bad_files(requests_mock, user1, projects_fixture, agave_utils_with_bad_image_file):
-    METADATA_ROUTE = re.compile(r'http://.*/meta/v2/data')
-    response = {"result": [{"value": {"geolocation": [{"longitude": 20, "latitude": 30}]}}]}
-    requests_mock.get(METADATA_ROUTE, json=response)
-
+def test_external_data_bad_files(metadata_none_fixture, user1, projects_fixture, agave_utils_with_bad_image_file):
     import_from_agave(projects_fixture.tenant_id, user1.id, "testSystem", "/testPath", projects_fixture.id)
     features = db_session.query(Feature).all()
     assert len(features) == 0
@@ -208,7 +217,6 @@ def test_external_data_no_files_except_for_trash(user1, projects_fixture, agave_
 
 
 @pytest.mark.worker
-@pytest.mark.skip(reason="TODO_TAPISV3 See https://tacc-main.atlassian.net/browse/WG-254")
 def test_external_data_rapp(user1, projects_fixture,
                             agave_utils_with_image_file_from_rapp_folder):
     import_from_agave(projects_fixture.tenant_id, user1.id, "testSystem", "/Rapp", projects_fixture.id)
@@ -223,11 +231,8 @@ def test_external_data_rapp(user1, projects_fixture,
 
 @pytest.mark.worker
 def test_external_data_rapp_missing_geospatial_metadata(user1, projects_fixture,
-                                                        agave_utils_with_image_file_from_rapp_folder, requests_mock):
-    METADATA_ROUTE = re.compile(r'http://.*/meta/v2/data')
-    response = {"result": [{"value": {"geolocation": []}}]}
-    requests_mock.get(METADATA_ROUTE, json=response)
-
+                                                        agave_utils_with_image_file_from_rapp_folder,
+                                                        metadata_but_no_geolocation_fixture):
     import_from_agave(projects_fixture.tenant_id, user1.id, "testSystem", "/Rapp", projects_fixture.id)
     features = db_session.query(Feature).all()
     assert len(features) == 0
@@ -357,7 +362,8 @@ def test_import_from_agave_failed_dbsession_rollback(agave_utils_with_geojson_fi
 
 
 @pytest.mark.worker
-def test_refresh_observable_projects(user1,
+def test_refresh_observable_projects(metadata_but_no_geolocation_fixture,
+                                     user1,
                                      user2,
                                      agave_utils_with_geojson_file,
                                      observable_projects_fixture,

--- a/geoapi/tests/fixtures/tapis_meta_no_geolocation.json
+++ b/geoapi/tests/fixtures/tapis_meta_no_geolocation.json
@@ -1,53 +1,32 @@
 {
-  "result": [
-    {
-      "uuid": "8979750356237676050-242ac117-0001-012",
-      "owner": "ds_admin",
-      "schemaId": null,
-      "internalUsername": null,
-      "associationIds": [],
-      "lastUpdated": "2024-01-16T17:11:00.585-06:00",
-      "name": "designsafe.file",
-      "value": {
-        "_author": "Test User",
-        "geolocation": [],
-        "instrument_manufacturer_and_model": "",
-        "title": "Photo 1688148916614",
-        "_timestamp": 1688148922.1698608,
-        "_rapp_parent_collection_uuid": "F45CD6A6-4DC0-42CE-A717-16045AF5F6A7",
-        "geoid_model": "",
-        "misc_notes": "",
-        "instrument_type": "other",
-        "coord_system_epoch": "",
-        "path": "/test_user/Photo1.jpg",
-        "system": "project-4193535358505521646-242ac117-0001-012",
-        "geodetic_datum": "",
-        "coord_ref_system": "",
-        "geodetic_datum_realization": "",
-        "basePath": "/test_user",
-        "vertical_datum": "",
-        "format": "jpg",
-        "_rapp_asset_uuid": "B28E06C3-9B14-4235-B307-2F0F5FA961C0",
-        "units": "",
-        "data_type": "image",
-        "referenced_data_links": [],
-        "coord_system": "",
-        "data_hazard_type": "other",
-        "description": ""
-      },
-      "created": "2024-01-16T17:11:00.585-06:00",
-      "_links": {
-        "self": {
-          "href": "https://agave.designsafe-ci.org/meta/v2/data/8979750356237676050-242ac117-0001-012"
-        },
-        "permissions": {
-          "href": "https://agave.designsafe-ci.org/meta/v2/data/8979750356237676050-242ac117-0001-012/pems"
-        },
-        "owner": {
-          "href": "https://agave.designsafe-ci.org/profiles/v2/ds_admin"
-        },
-        "associationIds": []
-      }
-    }
-  ]
+  "lastUpdated": "2024-01-20T07:05:01.333-06:00",
+  "name": "designsafe.file",
+  "value": {
+    "_author": "Test User",
+    "geolocation": [
+    ],
+    "instrument_manufacturer_and_model": "",
+    "title": "Photo 1690399237478",
+    "_timestamp": 1690399240.36766,
+    "_rapp_parent_collection_uuid": "CA16655D-A422-444D-A078-546BC5CF1C67",
+    "geoid_model": "",
+    "misc_notes": "",
+    "instrument_type": "other",
+    "coord_system_epoch": "",
+    "path": "/Photo 1690399237478.jpg",
+    "system": "project-4193535358505521646-242ac117-0001-012",
+    "geodetic_datum": "",
+    "coord_ref_system": "",
+    "geodetic_datum_realization": "",
+    "basePath": "/",
+    "vertical_datum": "",
+    "format": "jpg",
+    "_rapp_asset_uuid": "8C9E6B10-0A00-4F0B-BDD8-E443BDE64519",
+    "units": "",
+    "data_type": "image",
+    "referenced_data_links": [],
+    "coord_system": "",
+    "data_hazard_type": "other",
+    "description": ""
+  }
 }

--- a/geoapi/tests/fixtures/tapis_meta_with_geolocation.json
+++ b/geoapi/tests/fixtures/tapis_meta_with_geolocation.json
@@ -1,62 +1,40 @@
 {
-  "result": [
-    {
-      "uuid": "8846490921293573650-242ac117-0001-012",
-      "owner": "ds_admin",
-      "schemaId": null,
-      "internalUsername": null,
-      "associationIds": [],
-      "lastUpdated": "2024-01-20T07:05:01.333-06:00",
-      "name": "designsafe.file",
-      "value": {
-        "_author": "Test User",
-        "geolocation": [
-          {
-            "longitude": -122.30701480072206,
-            "timestamp": 1690399239.996102,
-            "latitude": 47.65349416532335,
-            "course": 305.5078125,
-            "heading": 318.62109375,
-            "altitude": 37.63900375366211
-          }
-        ],
-        "instrument_manufacturer_and_model": "",
-        "title": "Photo 1690399237478",
-        "_timestamp": 1690399240.36766,
-        "_rapp_parent_collection_uuid": "CA16655D-A422-444D-A078-546BC5CF1C67",
-        "geoid_model": "",
-        "misc_notes": "",
-        "instrument_type": "other",
-        "coord_system_epoch": "",
-        "path": "/Photo 1690399237478.jpg",
-        "system": "project-4193535358505521646-242ac117-0001-012",
-        "geodetic_datum": "",
-        "coord_ref_system": "",
-        "geodetic_datum_realization": "",
-        "basePath": "/",
-        "vertical_datum": "",
-        "format": "jpg",
-        "_rapp_asset_uuid": "8C9E6B10-0A00-4F0B-BDD8-E443BDE64519",
-        "units": "",
-        "data_type": "image",
-        "referenced_data_links": [],
-        "coord_system": "",
-        "data_hazard_type": "other",
-        "description": ""
-      },
-      "created": "2024-01-20T07:05:01.333-06:00",
-      "_links": {
-        "self": {
-          "href": "https://agave.designsafe-ci.org/meta/v2/data/8846490921293573650-242ac117-0001-012"
-        },
-        "permissions": {
-          "href": "https://agave.designsafe-ci.org/meta/v2/data/8846490921293573650-242ac117-0001-012/pems"
-        },
-        "owner": {
-          "href": "https://agave.designsafe-ci.org/profiles/v2/ds_admin"
-        },
-        "associationIds": []
+  "lastUpdated": "2024-01-20T07:05:01.333-06:00",
+  "name": "designsafe.file",
+  "value": {
+    "_author": "Test User",
+    "geolocation": [
+      {
+        "longitude": -122.30701480072206,
+        "timestamp": 1690399239.996102,
+        "latitude": 47.65349416532335,
+        "course": 305.5078125,
+        "heading": 318.62109375,
+        "altitude": 37.63900375366211
       }
-    }
-  ]
+    ],
+    "instrument_manufacturer_and_model": "",
+    "title": "Photo 1690399237478",
+    "_timestamp": 1690399240.36766,
+    "_rapp_parent_collection_uuid": "CA16655D-A422-444D-A078-546BC5CF1C67",
+    "geoid_model": "",
+    "misc_notes": "",
+    "instrument_type": "other",
+    "coord_system_epoch": "",
+    "path": "/Photo 1690399237478.jpg",
+    "system": "project-4193535358505521646-242ac117-0001-012",
+    "geodetic_datum": "",
+    "coord_ref_system": "",
+    "geodetic_datum_realization": "",
+    "basePath": "/",
+    "vertical_datum": "",
+    "format": "jpg",
+    "_rapp_asset_uuid": "8C9E6B10-0A00-4F0B-BDD8-E443BDE64519",
+    "units": "",
+    "data_type": "image",
+    "referenced_data_links": [],
+    "coord_system": "",
+    "data_hazard_type": "other",
+    "description": ""
+  }
 }

--- a/geoapi/tests/utils_tests/test_agave.py
+++ b/geoapi/tests/utils_tests/test_agave.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 from geoapi.utils.agave import AgaveUtils, AgaveFileGetError
 
 
-
 @pytest.fixture(scope="function")
 def retry_sleep_seconds_mock():
     with patch('geoapi.utils.agave.SLEEP_SECONDS_BETWEEN_RETRY', 0) as sleep_mock:

--- a/geoapi/tests/utils_tests/test_agave.py
+++ b/geoapi/tests/utils_tests/test_agave.py
@@ -2,22 +2,8 @@ import pytest
 import os
 import tempfile
 from unittest.mock import patch
-from geoapi.exceptions import MissingServiceAccount
-from geoapi.utils.agave import service_account_client, AgaveUtils, AgaveFileGetError
+from geoapi.utils.agave import AgaveUtils, AgaveFileGetError
 
-
-@pytest.mark.skip(reason="Skipping until https://tacc-main.atlassian.net/browse/WG-257")
-def test_service_account_client():
-    service_account = service_account_client("designsafe")
-    assert "ABCDEFG12344" in service_account.client.headers['Authorization']
-
-    service_account = service_account_client("DesignSafe")
-    assert "ABCDEFG12344" in service_account.client.headers['Authorization']
-
-
-def test_service_account_client_missing():
-    with pytest.raises(MissingServiceAccount):
-        service_account_client("non_existing_tenant")
 
 
 @pytest.fixture(scope="function")

--- a/geoapi/tests/utils_tests/test_geo_location.py
+++ b/geoapi/tests/utils_tests/test_geo_location.py
@@ -1,6 +1,5 @@
 from geoapi.utils.geo_location import get_geolocation_from_file_metadata, GeoLocation
 import re
-import pytest
 
 METADATA_ROUTE = re.compile(r'https://.*/api/filemeta/.*/.*')
 SYSTEM = "SYSTEM"

--- a/geoapi/tests/utils_tests/test_geo_location.py
+++ b/geoapi/tests/utils_tests/test_geo_location.py
@@ -2,7 +2,7 @@ from geoapi.utils.geo_location import get_geolocation_from_file_metadata, GeoLoc
 import re
 import pytest
 
-METADATA_ROUTE = re.compile(r'http://.*/meta/v2/data')
+METADATA_ROUTE = re.compile(r'https://.*/api/filemeta/.*/.*')
 SYSTEM = "SYSTEM"
 PATH = "PATH"
 

--- a/geoapi/tests/utils_tests/test_geo_location.py
+++ b/geoapi/tests/utils_tests/test_geo_location.py
@@ -8,11 +8,7 @@ PATH = "PATH"
 
 
 def test_no_metadata(requests_mock, user1):
-    response = {"result": [{}]}
-    requests_mock.get(METADATA_ROUTE, json=response)
-    assert get_geolocation_from_file_metadata(user1, system_id=SYSTEM, path=PATH) is None
-
-    response = {"result": []}
+    response = {}
     requests_mock.get(METADATA_ROUTE, json=response)
     assert get_geolocation_from_file_metadata(user1, system_id=SYSTEM, path=PATH) is None
 
@@ -23,7 +19,6 @@ def test_metadata_but_no_geolocation(requests_mock, user1, tapis_metadata_withou
     assert get_geolocation_from_file_metadata(user1, system_id=SYSTEM, path=PATH) is None
 
 
-@pytest.mark.skip(reason="Skipping until https://tacc-main.atlassian.net/browse/WG-254")
 def test_metadata_with_geolocation(requests_mock, user1, tapis_metadata_with_geolocation):
     requests_mock.get(METADATA_ROUTE, json=tapis_metadata_with_geolocation)
 

--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -311,11 +311,7 @@ def get_metadata_using_service_account(tenant_id: str, system_id: str, path: str
     logger.debug(f"getting metadata. tenant:{tenant_id}, system_id: {system_id}, path:{path}")
 
     client = service_account_client(tenant_id)
-    # TODO_TAPISV3 fix env file and service account information and update cache
-    # TODO_TAPISV3 environment variable for correct DesignSafe backend
-    # (i.e. https://www.designsafe-ci.org or https://designsafeci-dev.tacc.utexas.edu or  https://designsafeci-next.tacc.utexas.edu)
-    # See DESIGNSAFE_URL in geoapi/custom/designsafe/project.py and combine with that;  move this to custom/designsafe/?
-    client.base_url = "https://designsafeci-next.tacc.utexas.edu"
+    client.base_url = settings.DESIGNSAFE_URL
 
     response = client.get(url=quote(f'/api/filemeta/{system_id}/{path}'))
     response.raise_for_status()

--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -264,19 +264,18 @@ class AgaveUtils:
 
 
 def service_account_client(tenant_id):
-    # TODO_TAPISV3
     try:
         tenant_secrets = json.loads(settings.TENANT)
     except TypeError:
-        logger.error("Could not get service account for tenant:{};  Ensure this your environment "
-                     "is properly configured.".format(tenant_id))
+        logger.exception("Could not get service account for tenant:{};  Ensure this your environment "
+                         "is properly configured.".format(tenant_id))
         raise MissingServiceAccount
 
     if tenant_secrets is None or tenant_id.upper() not in tenant_secrets:
         raise MissingServiceAccount
 
-    # TODO_TAPISV3 update service account
-    client = AgaveUtils(token=tenant_secrets[tenant_id.upper()]['service_account_token'], tenant=tenant_id)
+    client = AgaveUtils(token=tenant_secrets[tenant_id.upper()]['tg458981_service_account_token'], tenant_id=tenant_id)
+    token = tenant_secrets[tenant_id.upper()]['tg458981_service_account_token']
     return client
 
 

--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -99,7 +99,6 @@ class AgaveUtils(ApiUtils):
         """
         super().__init__(user=user, base_url=get_api_server(user.tenant_id))
 
-
     def systemsGet(self, systemId: str) -> Dict:
         url = quote('/v3/systems/{}'.format(systemId))
         resp = self.get(url)
@@ -301,7 +300,6 @@ def get_metadata(user: User, system_id: str, path: str) -> Dict:
     logger.debug(f"getting metadata. system_id: {system_id}, path:{path}")
 
     client = ApiUtils(user=user, base_url=settings.DESIGNSAFE_URL)
-
     response = client.get(url=quote(f'/api/filemeta/{system_id}/{path}'))
     response.raise_for_status()
     meta_response = response.json()

--- a/geoapi/utils/geo_location.py
+++ b/geoapi/utils/geo_location.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from geoapi.utils.agave import get_metadata_using_service_account
+from geoapi.utils.agave import get_metadata
 from geoapi.models import User
 from typing import Optional
 
@@ -29,7 +29,7 @@ def get_geolocation_from_file_metadata(user: User, system_id: str, path: str) ->
 
     :return: A GeoLocation object if geolocation information is found; otherwise, None.
     """
-    meta = get_metadata_using_service_account(user.tenant_id, system_id, path)
+    meta = get_metadata(user, system_id, path)
     if meta and "geolocation" in meta and len(meta["geolocation"]) > 0:
         return parse_rapid_geolocation(meta.get("geolocation"))
     return None


### PR DESCRIPTION
## Overview: ##

Use file-metadata routes from DesignSafe.

This PR also:

 * Removes the use of service accounts bc814bd410e66eec5a10c3a67c2cb5f088bc9cbd
 * Adds some testing notes to Readme 71c1a0bbb16cd4a74f4139b1ee9527a3a69b560d

## Related Jira tickets: ##

* [WG-254](https://tacc-main.atlassian.net/browse/WG-254)

## Summary of Changes: ##

## Testing Steps: ##
0. Update `.env` from https://stache.utexas.edu/entry/892c730561534ed3b3d306dbf933455d so that you have new DESIGNSAFE_URL env variable.
2. Run this branch locally
3. Run `feature/tapisv3` hazmapper locally using  `backend: EnvironmentType.Local` in `angular/src/environments/environment.ts`
4. Make a map and add images `image.jpg` and `image_with_geolocation_tapis_metadata3.jpg
` from https://designsafeci-next.tacc.utexas.edu/data/browser/projects/PRJ-4576/workdir
5. Watch logs tosee that file metadata from`image_with_geolocation_tapis_metadata3.jpg` is being used

## Notes: ##

- [x]  fix env file and update cache
- [x]  use environment variable for correct DesignSafe backend (i.e. https://www.designsafe-ci.org or https://designsafeci-dev.tacc.utexas.edu or  https://designsafeci-next.tacc.utexas.edu)
