### PR TITLE
hotfix:  change status endpoint to no longer require authentication

### DIFF
--- a/geoapi/routes/status.py
+++ b/geoapi/routes/status.py
@@ -1,7 +1,6 @@
 from flask_restx import Resource, Namespace, fields
-import time
 from geoapi.log import logging
-from geoapi.utils.decorators import jwt_decoder, not_anonymous
+from geoapi.utils.decorators import jwt_decoder
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +16,5 @@ class Status(Resource):
     @api.doc(id="get",
              description='Get status')
     @api.marshal_with(status_response)
-    @not_anonymous
     def get(self):
-        time.sleep(1)
         return {"status": "OK"}

--- a/geoapi/tests/api_tests/test_status_routes.py
+++ b/geoapi/tests/api_tests/test_status_routes.py
@@ -1,6 +1,8 @@
 def test_get_status_unauthorized_guest(test_client, projects_fixture):
     resp = test_client.get('/status/')
-    assert resp.status_code == 403
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert data == {'status': 'OK'}
 
 
 def test_get_status(test_client, user1):


### PR DESCRIPTION
## Overview: ##

Change `/status/` endpoint so that it no longer requires authentication

I want to add backends directly to our monitoring due to the weird behavior we saw with `experimental.geoapi-services` yesterday