### PR TITLE
task/WG-296: fix projects meta endpoint usage

### DIFF
--- a/geoapi/custom/designsafe/project.py
+++ b/geoapi/custom/designsafe/project.py
@@ -5,6 +5,7 @@ from geoapi.settings import settings
 from geoapi.custom.designsafe.default_basemap_layers import default_layers
 from geoapi.models import User, Project
 
+
 def on_project_creation(database_session, user: User, project: Project):
     try:
         logger.debug(f"Creating .hazmapper file for user:{user.username}"

--- a/geoapi/custom/designsafe/project.py
+++ b/geoapi/custom/designsafe/project.py
@@ -5,9 +5,6 @@ from geoapi.settings import settings
 from geoapi.custom.designsafe.default_basemap_layers import default_layers
 from geoapi.models import User, Project
 
-import requests
-
-
 def on_project_creation(database_session, user: User, project: Project):
     try:
         logger.debug(f"Creating .hazmapper file for user:{user.username}"
@@ -79,9 +76,8 @@ def on_project_deletion(user: User, project: Project):
 def update_designsafe_project_hazmapper_metadata(user: User, project: Project, add_project: bool):
     designsafe_uuid = project.system_id[len("project-"):]
 
-    client = requests.Session()
-    client.headers.update({'X-JWT-Assertion-designsafe': user.jwt})
-
+    from geoapi.utils.agave import get_session
+    client = get_session(user)
     response = client.get(settings.DESIGNSAFE_URL + f"/api/projects/v2/{designsafe_uuid}/")
     response.raise_for_status()
 

--- a/geoapi/routes/__init__.py
+++ b/geoapi/routes/__init__.py
@@ -7,15 +7,10 @@ from .public_projects import api as public_projects
 
 api = Api(
     title='GeoAPI',
-    version='0.1',
+    version='0.2',
     description='Geospatial API for TAPIS',
-    security=['Token', 'JWT'],
+    security=['JWT'],
     authorizations={
-        'Token': {
-            'type': 'apiKey',
-            'name': 'Authorization',
-            'in': 'header'
-        },
         'JWT': {
             'type': 'apiKey',
             'name': 'X-Tapis-Token',

--- a/geoapi/routes/__init__.py
+++ b/geoapi/routes/__init__.py
@@ -18,7 +18,7 @@ api = Api(
         },
         'JWT': {
             'type': 'apiKey',
-            'name': 'X-JWT-Assertion-designsafe',
+            'name': 'X-Tapis-Token',
             'in': 'header'
         }
     }

--- a/geoapi/utils/agave.py
+++ b/geoapi/utils/agave.py
@@ -71,6 +71,17 @@ class AgaveFileListing:
         return self.path.suffix.lstrip('.').lower()
 
 
+def get_session(user: User):
+    """
+    Get the client session which contains correct headers
+
+    :param user: The user object containing the JWT.
+    """
+    client = requests.Session()
+    client.headers.update({'X-Tapis-Token': user.jwt})
+    return client
+
+
 class ApiUtils:
     def __init__(self, user: User, base_url: str):
         """
@@ -79,9 +90,7 @@ class ApiUtils:
         :param user: The user object containing the JWT.
         :param base_url: The base URL for the API endpoints.
         """
-        client = requests.Session()
-        client.headers.update({'X-Tapis-Token': user.jwt})
-        self.client = client
+        self.client = get_session(user)
         self.base_url = base_url
 
     def get(self, url, params=None):


### PR DESCRIPTION
## Overview: ##

Fix use of DS's project metadata endpoint on map-project creation/deletion.

 https://github.com/TACC-Cloud/geoapi/pull/199 was missing the changes to the header 

(at that time things were not deployed to ds-next so missed that)

## Related Jira tickets: ##

* [WG-296](https://tacc-main.atlassian.net/browse/WG-296)

## Summary of Changes: ##

## Testing Steps: ##
1. Create a map connected to a project
2. Check geoapi logs to see that no exceptions occurred
3. Delete that map
4. Check geoapi logs to see that no exceptions occurred
