### PR TITLE
task/WG-311: handle guest users

### DIFF
--- a/geoapi/custom/designsafe/project_users.py
+++ b/geoapi/custom/designsafe/project_users.py
@@ -26,6 +26,13 @@ def get_project_data(user: User,  system_id: str) -> dict:
     return project
 
 
+def _is_designsafe_project_guest_user(user):
+    if "username" not in user or user["role"] == "guest":
+        return True
+    else:
+        return False
+
+
 def get_system_users(user, system_id: str):
     """
     Get systems users based on the DesignSafe project's co-pis and pis.
@@ -46,7 +53,7 @@ def get_system_users(user, system_id: str):
     users = {}
     for u in project["users"]:
         is_admin = u["role"] in ("pi", "co_pi")
-        if u["username"] not in users:
+        if (not _is_designsafe_project_guest_user(u) and u["username"] not in users):
             users[u["username"]] = SystemUser(username=u["username"], admin=is_admin)
         else:
             # there can be duplicates (seen in v2) so we want to ensure we have the "admin=True" version of a duplicate

--- a/geoapi/tests/fixtures/designsafe_api_project.json
+++ b/geoapi/tests/fixtures/designsafe_api_project.json
@@ -41,7 +41,7 @@
                 {
                     "inst": "MyInstitution",
                     "role": "guest",
-                    "email": "nathan.franklin@gmail.com",
+                    "email": "geust@guest.com",
                     "fname": "FirstNameGuest",
                     "lname": "LastNameGuest"
                 }

--- a/geoapi/tests/fixtures/designsafe_api_project.json
+++ b/geoapi/tests/fixtures/designsafe_api_project.json
@@ -37,6 +37,13 @@
                 {
                     "role": "team_member",
                     "username": "user4"
+                },
+                {
+                    "inst": "MyInstitution",
+                    "role": "guest",
+                    "email": "nathan.franklin@gmail.com",
+                    "fname": "FirstNameGuest",
+                    "lname": "LastNameGuest"
                 }
             ],
             "projectType": "None",


### PR DESCRIPTION
## Overview: ##

Handle guest users in v3 DesignSafe projects 
## Related Jira tickets: ##

* [WG-311](https://tacc-main.atlassian.net/browse/WG-311)

## Summary of Changes: ##

## Testing Steps: ##
1.  Create project on DS-Next where there is a guest user
2. Confirm that you can create a hazmapper map project for that DS project. Confirm the right users show up and no errors in log during map creation.