### PR TITLE
hotifx: trash is being scraped in TAPIS-v3

### DIFF
--- a/geoapi/tasks/external_data.py
+++ b/geoapi/tasks/external_data.py
@@ -288,7 +288,7 @@ def import_from_files_from_path(session, tenant_id: str, userId: int, systemId: 
 
     filenames_in_directory = [str(f.path) for f in listing]
     for item in listing:
-        if item.type == "dir" and not str(item.path).endswith("/.Trash"):
+        if item.type == "dir" and not str(item.path).endswith(".Trash"):
             import_from_files_from_path(session, tenant_id, userId, systemId, item.path, projectId)
         item_system_path = os.path.join(systemId, str(item.path).lstrip("/"))
         if features_util.is_file_supported_for_automatic_scraping(item_system_path):

--- a/geoapi/tests/external_data_tests/test_external_data.py
+++ b/geoapi/tests/external_data_tests/test_external_data.py
@@ -137,7 +137,7 @@ def agave_utils_listing_with_single_trash_folder_of_image(image_file_fixture):
 
     top_level_file_listing = [
         AgaveFileListing({
-            "path": "/.Trash",
+            "path": ".Trash",
             "type": "dir",
             "lastModified": "2020-08-31T12:00:00Z"
         })
@@ -145,7 +145,7 @@ def agave_utils_listing_with_single_trash_folder_of_image(image_file_fixture):
     subfolder_file_listing = [
         AgaveFileListing({
             "type": "file",
-            "path": "/.Trash/file.jpg",
+            "path": ".Trash/file.jpg",
             "lastModified": "2020-08-31T12:00:00Z"
         })
     ]


### PR DESCRIPTION
## Overview: ##

We want to skip the scraping of trash files.  Now top-level trash directories have a path of `.Trash` instead of `./Trash`.  This PR updates our logic when scraping files.
