### PR TITLE
hotfix:  Add hazmapper.local to client_urls

### DIFF
--- a/geoapi/routes/auth.py
+++ b/geoapi/routes/auth.py
@@ -39,6 +39,7 @@ def get_client_url(url):
     """
     client_urls = [
         "http://localhost:4200/",
+        "http://hazmapper.local:4200/",
         "https://hazmapper.tacc.utexas.edu/hazmapper/",
         "https://hazmapper.tacc.utexas.edu/staging/",
         "https://hazmapper.tacc.utexas.edu/dev/",


### PR DESCRIPTION
## Overview: ##

Add hazmapper.local to client_urls.  Now angular` `http://hazmapper.local:4200/` will work via `npm run start:local`.
