### PR TITLE
hotfix: stop deploying latest as Jenkins handles that for main branch building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,7 @@ deploy:
 .PHONY: deploy-geoapi
 deploy-geoapi:
 	docker push $(GEOAPI_IMAGE):$(TAG)
-	docker push $(GEOAPI_IMAGE):latest
 
 .PHONY: deploy-workers
 deploy-workers:
 	docker push $(GEOAPI_WORKERS):$(TAG)
-	docker push $(GEOAPI_WORKERS):latest


### PR DESCRIPTION
## Overview: ##

Fix makefile so we don't push a `latest` tagged image to dockerhub.  Pushing of latest images is handled by [jenkins job ](https://jenkins.portals.tacc.utexas.edu/view/Hazmapper%20+%20Geoapi/job/Geoapi%20(build%20image)/configure)which pushes latest only when on main branch.

This was causing issues as we have some automatic deployment (via watchtower) of the latest on the dev environment, which would sometimes break when non-main images were pushed.

## Related Jira tickets: ##

None

