### PR TITLE
hotfix: keep only 2 weeks of staging backups

### DIFF
--- a/devops/utils/backup_staging_production_to_ranch.sh
+++ b/devops/utils/backup_staging_production_to_ranch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-echo "Removing backups older than 6 weeks (i.e. 42 days) (STAGING)"
+echo "Removing backups older than 2 weeks (i.e. 14 days) (STAGING)"
 ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu 'find /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/staging/ -mtime +42 -type f -exec rm {} +'
 
 echo "Backing up staging"

--- a/devops/utils/backup_staging_production_to_ranch.sh
+++ b/devops/utils/backup_staging_production_to_ranch.sh
@@ -2,7 +2,7 @@
 set -ex
 
 echo "Removing backups older than 2 weeks (i.e. 14 days) (STAGING)"
-ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu 'find /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/staging/ -mtime +42 -type f -exec rm {} +'
+ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu 'find /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/staging/ -mtime +14 -type f -exec rm {} +'
 
 echo "Backing up staging"
 ssh -o StrictHostKeyChecking=no portal@staging.geoapi-services.tacc.utexas.edu "

--- a/devops/utils/backup_staging_production_to_ranch.sh
+++ b/devops/utils/backup_staging_production_to_ranch.sh
@@ -17,8 +17,8 @@ echo "Finished with STAGING and beginning PRODUCTION"
 echo "--------------------------------------------------"
 echo "--------------------------------------------------"
 
-echo "Removing backups older than 6 weeks (i.e. 42 days) (PRODUCTION)"
-ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu 'find /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/production/ -mtime +42 -type f -exec rm {} +'
+echo "Removing backups older than 4 weeks (i.e. 28 days) (PRODUCTION)"
+ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu 'find /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/production/ -mtime +28 -type f -exec rm {} +'
 
 echo "Backing up production"
 ssh -o StrictHostKeyChecking=no portal@prod.geoapi-services.tacc.utexas.edu "


### PR DESCRIPTION
## Overview: ##

Free up some backup space
* by removing backups older than 2 weeks of **staging** data (instead of 6 weeks) before creating a new backup 
* by removing backups older than 4 weeks of **production** data (instead of 6 weeks) before creating a new backup

See https://tacc-team.slack.com/archives/C04TMKBDS1X/p1735829948900709?thread_ts=1735829239.120209&cid=C04TMKBDS1X

