### PR TITLE
update: use separate worker service for each queue

### DIFF
--- a/devops/docker-compose.local.yml
+++ b/devops/docker-compose.local.yml
@@ -6,6 +6,25 @@ volumes:
 networks:
   geoapi:
 
+x-worker-base: &worker-base  # Base template for workers
+  image: taccaci/geoapi-workers:local
+  networks:
+    - geoapi
+  volumes:
+    - ../:/app
+    - assets:/assets
+  environment:
+    - MAPILLARY_CLIENT_TOKEN
+    - FLASK_APP=/app/geoapi/app.py
+    - APP_ENV=local
+    - ASSETS_BASE_DIR=/assets
+    - DESIGNSAFE_URL=${DESIGNSAFE_URL}
+  stdin_open: true
+  tty: true
+  depends_on:
+    rabbitmq:
+      condition: service_healthy
+
 services:
 
   rabbitmq:
@@ -47,34 +66,17 @@ services:
     networks:
       - geoapi
 
-
   workers:
-    image: taccaci/geoapi-workers:local
-    networks:
-      - geoapi
-    volumes:
-      - ../:/app
-      - assets:/assets
-    environment:
-      - MAPILLARY_CLIENT_TOKEN
-      - FLASK_APP=/app/geoapi/app.py
-      - APP_ENV=local
-      - ASSETS_BASE_DIR=/assets
-      - DESIGNSAFE_URL=${DESIGNSAFE_URL}
-
-    stdin_open: true
-    tty: true
+    <<: *worker-base
     container_name: geoapiworkers
     hostname: geoapiworkers
-    command: >
-      sh -c '
-      celery -A geoapi.celery_app worker -l info -Q default -n default_worker@geoapi &
-      celery -A geoapi.celery_app worker -l info -Q heavy --concurrency=6 -n heavy_worker@geoapi &
-      wait
-      '
-    depends_on:
-      rabbitmq:
-        condition: service_healthy
+    command: celery -A geoapi.celery_app worker -l info -Q default -n default_worker@geoapi
+
+  workers-heavy:
+    <<: *worker-base
+    container_name: geoapiworkers-heavy
+    hostname: geoapiworkers-heavy
+    command: celery -A geoapi.celery_app worker -l info -Q heavy --concurrency=6
 
   celerybeat:
     image: taccaci/geoapi-workers:local

--- a/devops/docker-compose.local.yml
+++ b/devops/docker-compose.local.yml
@@ -6,7 +6,8 @@ volumes:
 networks:
   geoapi:
 
-x-worker-base: &worker-base  # Base template for workers
+x-worker-base: &worker-base  # Base fragment for worker services
+  # See: https://docs.docker.com/reference/compose-file/fragments/
   image: taccaci/geoapi-workers:local
   networks:
     - geoapi
@@ -67,13 +68,13 @@ services:
       - geoapi
 
   workers:
-    <<: *worker-base
+    <<: *worker-base  # Reuses worker-base fragment defined at start
     container_name: geoapiworkers
     hostname: geoapiworkers
     command: celery -A geoapi.celery_app worker -l info -Q default -n default_worker@geoapi
 
   workers-heavy:
-    <<: *worker-base
+    <<: *worker-base  # Reuses worker-base fragment defined at start
     container_name: geoapiworkers-heavy
     hostname: geoapiworkers-heavy
     command: celery -A geoapi.celery_app worker -l info -Q heavy --concurrency=6


### PR DESCRIPTION
## Overview: ##

This PR changes the local dev docker compose so that we have a single worker service for each queue. So now instead of one worker service running celery twice, we have a service for the heavy queue and a service for the default queue.

In https://github.com/TACC-Cloud/geoapi/pull/220, we added a heavy queue.  Two comments at the time were about
* how the celery tasks was running twice and not in foreground in the worker service https://github.com/TACC-Cloud/geoapi/pull/220#discussion_r1824957416
* how we couldn't see in the logs the queue being run on: https://github.com/TACC-Cloud/geoapi/pull/220#discussion_r1825055954

## Testing Steps: ##
1. Confirm you can load an image (default queue) and import a point cloud (heavy queue)