### PR TITLE
hotfix: return 404 if project uuid is invalid

### DIFF
--- a/geoapi/tests/api_tests/test_projects_routes.py
+++ b/geoapi/tests/api_tests/test_projects_routes.py
@@ -83,6 +83,15 @@ def test_get_projects_using_single_uuid_that_is_wrong(test_client, user1):
     )
     assert resp.status_code == 404
 
+    # a non-uuid should return 404
+    resp = test_client.get(
+        "/projects/",
+        query_string="uuid={}".format("dummy"),
+        headers={"X-Tapis-Token": user1.jwt},
+    )
+    assert resp.status_code == 404
+    assert "Invalid project UUID" in resp.text
+
 
 def test_get_public_project_using_single_uuid(test_client, public_projects_fixture):
     resp = test_client.get(

--- a/geoapi/utils/decorators.py
+++ b/geoapi/utils/decorators.py
@@ -1,6 +1,7 @@
 from functools import wraps
 from flask import abort
 from flask import request
+from uuid import UUID
 from geoapi.services.users import UserService
 from geoapi.services.projects import ProjectsService
 from geoapi.services.features import FeaturesService
@@ -65,6 +66,13 @@ def check_access_and_get_project(
     :param allow_public_use: boolean
     :return: project: Project
     """
+    # Validate UUID format if uuid is provided
+    if uuid is not None:
+        try:
+            UUID(uuid)
+        except ValueError:
+            abort(404, "Invalid project UUID")
+
     proj = (
         ProjectsService.get(db_session, user=current_user, project_id=project_id)
         if project_id


### PR DESCRIPTION
## Overview: ##

Update project GET so that if a project uuid is incorrect it also returns 404.
