### PR TITLE
task/WG-435 - Update nginx conf to use compression

### DIFF
--- a/devops/hazmapper/nginx.conf
+++ b/devops/hazmapper/nginx.conf
@@ -23,6 +23,15 @@ http {
     keepalive_timeout   65;
     types_hash_max_size 2048;
 
+    gzip on;
+    gzip_comp_level 6;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_min_length 1000;
+    gzip_types application/json text/plain text/css application/javascript
+               text/javascript image/svg+xml application/x-javascript
+               font/woff font/woff2;
+
     include             /etc/nginx/mime.types;
     default_type        application/octet-stream;
 


### PR DESCRIPTION
## Overview: ##

This PR updates our copy of nginx.conf for hazmapper.tacc.utexas.edu to add copression.

**Note**: This has already been manually updated on hazmapper.tacc.utexas.edu

## Related Jira tickets: ##

* [WG-435](https://tacc-main.atlassian.net/browse/WG-435)

## Testing Steps: ##
1.  could confirm that deployed endpoints are using compression for gzip: `curl -H "Accept-Encoding: gzip" -I https://hazmapper.tacc.utexas.edu/geoapi/` or check features endpoint in dev tools for a map with lots of features

