### PR TITLE
hotfix: use migration to nullify streetview tokens

### DIFF
--- a/geoapi/migrations/versions/20250414_1430-nullify_legacy_tokens.py
+++ b/geoapi/migrations/versions/20250414_1430-nullify_legacy_tokens.py
@@ -1,0 +1,35 @@
+"""nullify_legacy_tokens
+
+
+This notifies legacy streetview tokens. Should have been done in
+9ca03b666aee
+
+Revision ID: a1b2c3d4e5f6
+Revises: 9ca03b666aee
+Create Date: 2025-04-14 14:30:00.000000
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "9ca03b666aee"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        UPDATE streetview
+        SET token = NULL
+        WHERE token_expires_at IS NULL AND token IS NOT NULL
+    """
+    )
+
+
+def downgrade():
+    # This operation is not reversible
+    pass

--- a/geoapi/services/streetview.py
+++ b/geoapi/services/streetview.py
@@ -26,14 +26,7 @@ class StreetviewService:
         """
         changes_made = False
         for streetview in streetviews:
-            if streetview.token_expires_at is None and streetview.token is not None:
-                logger.info(
-                    f"Token missing token_expires_at so for streetview service {streetview.service}, so nullifying token info"
-                )
-                streetview.token = None
-                streetview.token_expires_at = None
-                changes_made = True
-            else:
+            if streetview.token_expires_at is not None:
                 now_with_tz = datetime.now().astimezone(
                     streetview.token_expires_at.tzinfo
                 )

--- a/geoapi/tests/api_tests/test_streetview_routes.py
+++ b/geoapi/tests/api_tests/test_streetview_routes.py
@@ -29,11 +29,12 @@ def streetview_service_resource_expired_fixture(streetview_service_resource_fixt
 
 
 @pytest.fixture(scope="function")
-def streetview_service_resource_missing_token_expires_at_fixture(
+def streetview_service_resource_nulled_token_fixture(
     streetview_service_resource_fixture,
 ):
     sv = streetview_service_resource_fixture
     sv.token_expires_at = None
+    sv.token = None
     db_session.commit()
     return sv
 
@@ -104,7 +105,7 @@ def test_list_streetview_service_expired_resource(
 
 
 def test_list_streetview_service_missing_token_expires_at_resource(
-    test_client, streetview_service_resource_missing_token_expires_at_fixture
+    test_client, streetview_service_resource_nulled_token_fixture
 ):
     u1 = db_session.get(User, 1)
     resp = test_client.get("/streetview/services/", headers={"X-Tapis-Token": u1.jwt})
@@ -125,7 +126,7 @@ def test_list_streetview_service_missing_token_expires_at_resource(
     # Assert token was nulled in DB
     sv = (
         db_session.query(Streetview)
-        .filter_by(id=streetview_service_resource_missing_token_expires_at_fixture.id)
+        .filter_by(id=streetview_service_resource_nulled_token_fixture.id)
         .first()
     )
     assert sv is not None


### PR DESCRIPTION
## Overview: ##

https://github.com/TACC-Cloud/geoapi/pull/244 had an error as didn't account for nullified tokens. This PR refactors the logic to instead use a migration that nullifies any existing tokens lacking an expiration date. With that cleanup in place, we can handle expired tokens more cleanly in code going forward.

## Testing Steps: ##
1. Check unit tests and we'll test on staging

