### PR TITLE
Task/wg 550 improve backup script

### DIFF
--- a/devops/utils/backup_staging_production_to_ranch.sh
+++ b/devops/utils/backup_staging_production_to_ranch.sh
@@ -8,18 +8,16 @@ ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu \
 echo "Backing up staging"
 ssh -o StrictHostKeyChecking=no portal@staging.geoapi-services.tacc.utexas.edu bash -lc '
   set -Exeuo pipefail
+
   # skipping /assets/streetview as those are temp files
   tar \
-      --warning=no-absolute-paths \
-      --exclude=/assets/streetview \
+      -C / \
       --exclude=assets/streetview \
-      --exclude=/assets/lost+found \
       --exclude=assets/lost+found \
-      --exclude=/assets/bug \
       --exclude=assets/bug \
-      -c -f - /assets/ \
+      -c -f - assets \
   | ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu \
-      "split -b 300G - /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/staging/staging_assets\$(date +%Y-%m-%d).tar."
+      split -b 300G - /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/staging/staging_assets$(date +%Y-%m-%d).tar.
 '
 
 echo "Finished with STAGING and beginning PRODUCTION"
@@ -35,14 +33,11 @@ ssh -o StrictHostKeyChecking=no portal@prod.geoapi-services.tacc.utexas.edu bash
   set -Exeuo pipefail
   # skipping /assets/streetview as those are temp files
   tar \
-      --warning=no-absolute-paths \
-      --exclude=/assets/streetview \
+      -C / \
       --exclude=assets/streetview \
-      --exclude=/assets/lost+found \
       --exclude=assets/lost+found \
-      --exclude=/assets/bug \
       --exclude=assets/bug \
-      -c -f - /assets/ \
+      -c -f - assets \
   | ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu \
-      "split -b 300G - /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/production/production_assets\$(date +%Y-%m-%d).tar."
+      split -b 300G - /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/production/production_assets$(date +%Y-%m-%d).tar.
 '

--- a/devops/utils/backup_staging_production_to_ranch.sh
+++ b/devops/utils/backup_staging_production_to_ranch.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -Exeuo pipefail
 
-echo "Removing backups older than 2 weeks (i.e. 14 days) (STAGING)"
+echo "Removing backups older than 1 week (i.e. 7 days) (STAGING)"
 ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu \
-  'find /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/staging/ -mtime +14 -type f -exec rm {} +'
+  'find /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/staging/ -mtime +7 -type f -exec rm {} +'
 
 echo "Backing up staging"
 ssh -o StrictHostKeyChecking=no portal@staging.geoapi-services.tacc.utexas.edu bash -lc '
@@ -24,9 +24,9 @@ echo "Finished with STAGING and beginning PRODUCTION"
 echo "--------------------------------------------------"
 echo "--------------------------------------------------"
 
-echo "Removing backups older than 4 weeks (i.e. 28 days) (PRODUCTION)"
+echo "Removing backups older than 3 weeks (i.e. 21 days) (PRODUCTION)"
 ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu \
-  'find /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/production/ -mtime +28 -type f -exec rm {} +'
+  'find /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/production/ -mtime +21 -type f -exec rm {} +'
 
 echo "Backing up production"
 ssh -o StrictHostKeyChecking=no portal@prod.geoapi-services.tacc.utexas.edu bash -lc '

--- a/devops/utils/backup_staging_production_to_ranch.sh
+++ b/devops/utils/backup_staging_production_to_ranch.sh
@@ -1,29 +1,38 @@
 #!/bin/bash
-set -ex
+set -Exeuo pipefail
 
 echo "Removing backups older than 2 weeks (i.e. 14 days) (STAGING)"
-ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu 'find /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/staging/ -mtime +14 -type f -exec rm {} +'
+ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu \
+  'find /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/staging/ -mtime +14 -type f -exec rm {} +'
 
 echo "Backing up staging"
-ssh -o StrictHostKeyChecking=no portal@staging.geoapi-services.tacc.utexas.edu "
-set -ex
-# skipping /assets/streetview as those are temp files
-tar --exclude=/assets/streetview --exclude=/assets/lost+found --exclude=/assets/bug/ -c -f - /assets/ | \
-ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu 'split -b 300G - /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/staging/staging_assets\\$(date +%Y-%m-%d).tar.'
-"
+ssh -o StrictHostKeyChecking=no portal@staging.geoapi-services.tacc.utexas.edu bash -lc '
+  set -Exeuo pipefail
+  # skipping /assets/streetview as those are temp files
+  tar --exclude=/assets/streetview \
+      --exclude=/assets/lost+found \
+      --exclude=/assets/bug/ \
+      -c -f - /assets/ \
+  | ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu \
+      "split -b 300G - /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/staging/staging_assets\$(date +%Y-%m-%d).tar."
+'
 
 echo "Finished with STAGING and beginning PRODUCTION"
-
 echo "--------------------------------------------------"
 echo "--------------------------------------------------"
 
 echo "Removing backups older than 4 weeks (i.e. 28 days) (PRODUCTION)"
-ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu 'find /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/production/ -mtime +28 -type f -exec rm {} +'
+ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu \
+  'find /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/production/ -mtime +28 -type f -exec rm {} +'
 
 echo "Backing up production"
-ssh -o StrictHostKeyChecking=no portal@prod.geoapi-services.tacc.utexas.edu "
-set -ex
-# skipping /assets/streetview as those are temp files
-tar --exclude=/assets/streetview  --exclude=/assets/lost+found --exclude=/assets/bug/ -c -f - /assets/ | \
-ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu 'split -b 300G - /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/production/production_assets\\$(date +%Y-%m-%d).tar.'
-"
+ssh -o StrictHostKeyChecking=no portal@prod.geoapi-services.tacc.utexas.edu bash -lc '
+  set -Exeuo pipefail
+  # skipping /assets/streetview as those are temp files
+  tar --exclude=/assets/streetview \
+      --exclude=/assets/lost+found \
+      --exclude=/assets/bug/ \
+      -c -f - /assets/ \
+  | ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu \
+      "split -b 300G - /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/production/production_assets\$(date +%Y-%m-%d).tar."
+'

--- a/devops/utils/backup_staging_production_to_ranch.sh
+++ b/devops/utils/backup_staging_production_to_ranch.sh
@@ -9,9 +9,14 @@ echo "Backing up staging"
 ssh -o StrictHostKeyChecking=no portal@staging.geoapi-services.tacc.utexas.edu bash -lc '
   set -Exeuo pipefail
   # skipping /assets/streetview as those are temp files
-  tar --exclude=/assets/streetview \
+  tar \
+      --warning=no-absolute-paths \
+      --exclude=/assets/streetview \
+      --exclude=assets/streetview \
       --exclude=/assets/lost+found \
-      --exclude=/assets/bug/ \
+      --exclude=assets/lost+found \
+      --exclude=/assets/bug \
+      --exclude=assets/bug \
       -c -f - /assets/ \
   | ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu \
       "split -b 300G - /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/staging/staging_assets\$(date +%Y-%m-%d).tar."
@@ -29,9 +34,14 @@ echo "Backing up production"
 ssh -o StrictHostKeyChecking=no portal@prod.geoapi-services.tacc.utexas.edu bash -lc '
   set -Exeuo pipefail
   # skipping /assets/streetview as those are temp files
-  tar --exclude=/assets/streetview \
+  tar \
+      --warning=no-absolute-paths \
+      --exclude=/assets/streetview \
+      --exclude=assets/streetview \
       --exclude=/assets/lost+found \
-      --exclude=/assets/bug/ \
+      --exclude=assets/lost+found \
+      --exclude=/assets/bug \
+      --exclude=assets/bug \
       -c -f - /assets/ \
   | ssh -o StrictHostKeyChecking=no tg458981@ranch.tacc.utexas.edu \
       "split -b 300G - /stornext/ranch_01/ranch/projects/DesignSafe-Community/geoapi_assets_backup/production/production_assets\$(date +%Y-%m-%d).tar."


### PR DESCRIPTION
## Overview: ##

This fixes the backup script as errors in tar where getting lost in the pipe.

This PR also:
* fixes how we exclude things (which removes a warning)
* reduces how many backups we keep (4 weeks for prod and 2 weeks for staging)

## Related Jira tickets: ##

* [WG-550](https://tacc-main.atlassian.net/browse/WG-550)

## Summary of Changes: ##

## Testing Steps: ##
None, but its running now (https://jenkins.portals.tacc.utexas.edu/job/Geoapi%20(assets%20backup)%20-%20DEPRECATED%20for%20SCRIPT%20VERSION/52/) and ran once last week (https://jenkins.portals.tacc.utexas.edu/job/Geoapi%20(assets%20backup)%20-%20DEPRECATED%20for%20SCRIPT%20VERSION/50/ ; i checked these results after the run and size is correct)