### PR TITLE
task/WG-642: fix issues with large geotiff importing

### DIFF
--- a/devops/docker-compose.local.yml
+++ b/devops/docker-compose.local.yml
@@ -46,6 +46,8 @@ services:
     ports:
       - 15672:15672
     container_name: geoapi_rabbitmq
+    volumes:
+      - ./local_conf/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     environment:
       - RABBITMQ_DEFAULT_USER=dev
       - RABBITMQ_DEFAULT_PASS=dev

--- a/devops/local_conf/rabbitmq.conf
+++ b/devops/local_conf/rabbitmq.conf
@@ -1,0 +1,6 @@
+# Increase RabbitMQ consumer ack timeout from 30min to 5hrs.
+# Workers buffer unacknowledged messages during long tasks (like COG/point
+# cloud conversions). With the default timeout, unacknowledged messages
+# hit the limit and crash the worker with PRECONDITION_FAILED.
+# See: https://www.rabbitmq.com/docs/consumers#acknowledgement-timeout
+consumer_timeout = 18000000

--- a/geoapi/celery_app.py
+++ b/geoapi/celery_app.py
@@ -36,6 +36,15 @@ app.conf.task_queues = {
 
 app.conf.task_default_queue = "default"
 
+# Minimize prefetching (1 extra message per worker child instead of the
+# default 4*concurrency to be pulled). Prefetched messages are marked as
+# "delivered" by RabbitMQ, which starts the consumer_timeout ack timer
+# (default 30min). For long-running tasks (e.g. cog conversion, potree conversion),
+# prefetched messages then can sit unacknowledged long enough to trigger the timeout
+# and crash the entire worker.
+# See: https://www.rabbitmq.com/docs/consumers#acknowledgement-timeout
+app.conf.worker_prefetch_multiplier = 1
+
 app.conf.beat_schedule = {
     "refresh_projects_watch_content": {
         "task": "geoapi.tasks.external_data.refresh_projects_watch_content",

--- a/geoapi/custom/designsafe/default_basemap_layers.py
+++ b/geoapi/custom/designsafe/default_basemap_layers.py
@@ -9,7 +9,7 @@ default_layers = [
             "isActive": True,
             "showDescription": False,
             "showInput": False,
-            "zIndex": 0,
+            "zIndex": -1,
         },
         "tileOptions": {
             "minZoom": 0,
@@ -28,7 +28,7 @@ default_layers = [
             "isActive": True,
             "showDescription": False,
             "showInput": False,
-            "zIndex": -1,
+            "zIndex": -2,
         },
         "tileOptions": {
             "minZoom": 0,

--- a/geoapi/services/tile_server.py
+++ b/geoapi/services/tile_server.py
@@ -40,17 +40,21 @@ class TileService:
         :param data: Dict
         :return: ts: TileServer
         """
-        existing_z = data.get('uiOptions', {}).get('zIndex', 0)
+        existing_z = data.get("uiOptions", {}).get("zIndex", 0)
         if existing_z == 0:
             # New layer with default zIndex
             # So, we place on top by finding current top first
-            max_z = database_session.query(
-                func.max(TileServer.uiOptions['zIndex'].as_integer())
-            ).filter(TileServer.project_id == projectId).scalar()
+            max_z = (
+                database_session.query(
+                    func.max(TileServer.uiOptions["zIndex"].as_integer())
+                )
+                .filter(TileServer.project_id == projectId)
+                .scalar()
+            )
 
-            if 'uiOptions' not in data:
-                data['uiOptions'] = {}
-            data['uiOptions']['zIndex'] = (max_z + 1) if max_z is not None else 0
+            if "uiOptions" not in data:
+                data["uiOptions"] = {}
+            data["uiOptions"]["zIndex"] = (max_z + 1) if max_z is not None else 0
 
         ts = TileServer()
 

--- a/geoapi/services/tile_server.py
+++ b/geoapi/services/tile_server.py
@@ -52,7 +52,7 @@ class TileService:
                 .scalar()
             )
 
-            if "uiOptions" not in data:
+            if not data.get("uiOptions"):
                 data["uiOptions"] = {}
             data["uiOptions"]["zIndex"] = (max_z + 1) if max_z is not None else 0
 

--- a/geoapi/services/tile_server.py
+++ b/geoapi/services/tile_server.py
@@ -5,7 +5,7 @@ from geoapi.models import TileServer, Task, User
 from geoapi.schema.tapis import TapisFilePath
 from geoapi.log import logger
 from geoapi.utils.assets import delete_assets
-from sqlalchemy import inspect
+from sqlalchemy import inspect, func
 from sqlalchemy.dialects.postgresql import JSONB
 
 
@@ -40,6 +40,18 @@ class TileService:
         :param data: Dict
         :return: ts: TileServer
         """
+        existing_z = data.get('uiOptions', {}).get('zIndex', 0)
+        if existing_z == 0:
+            # New layer with default zIndex
+            # So, we place on top by finding current top first
+            max_z = database_session.query(
+                func.max(TileServer.uiOptions['zIndex'].as_integer())
+            ).filter(TileServer.project_id == projectId).scalar()
+
+            if 'uiOptions' not in data:
+                data['uiOptions'] = {}
+            data['uiOptions']['zIndex'] = (max_z + 1) if max_z is not None else 0
+
         ts = TileServer()
 
         for key, value in data.items():

--- a/geoapi/services/tile_server.py
+++ b/geoapi/services/tile_server.py
@@ -40,7 +40,7 @@ class TileService:
         :param data: Dict
         :return: ts: TileServer
         """
-        existing_z = data.get("uiOptions", {}).get("zIndex", 0)
+        existing_z = (data.get("uiOptions") or {}).get("zIndex", 0)
         if existing_z == 0:
             # New layer with default zIndex
             # So, we place on top by finding current top first

--- a/geoapi/tasks/raster.py
+++ b/geoapi/tasks/raster.py
@@ -31,6 +31,17 @@ def _validate_raster_name(name: str) -> None:
         )
 
 
+def is_8bit_rgb_or_rgba(src: Path) -> bool:
+    result = subprocess.run(
+        ["gdalinfo", "-json", str(src)],
+        capture_output=True, text=True
+    )
+    info = json.loads(result.stdout)
+    dtype = info["bands"][0]["type"]
+    band_count = len(info["bands"])
+    return dtype == "Byte" and band_count in (3, 4)
+
+
 def gdal_cogify(src: Path, dst: Path) -> None:
     """Convert to COG"""
 
@@ -60,6 +71,23 @@ def gdal_cogify(src: Path, dst: Path) -> None:
         str(src),
         str(dst),
     ]
+
+    if is_8bit_rgb_or_rgba(src):
+        # 8-bit RGB/RGBA imagery (orthomosaics, aerial photos).
+        # So we use JPEG compression
+        compression = ["-co", "COMPRESS=JPEG", "-co", "QUALITY=85"]
+    else:
+        # Everytyhing lese (like DEMs, multi-band, 16-bit, float) we
+        # use a lossless compression as pixel values matter. ZSTD is
+        # lossless with fast decompression..
+        compression = [
+            "-co", "COMPRESS=ZSTD",
+            "-co", "PREDICTOR=YES",
+            "-co", "LEVEL=3",
+        ]
+
+    cmd = cmd + compression + [str(src), str(dst)]
+
     logger.info(f"Converting to cog by running command: {' '.join(cmd)}")
 
     # GDAL creates temp files in the current working directory during COG conversion,

--- a/geoapi/tasks/raster.py
+++ b/geoapi/tasks/raster.py
@@ -43,6 +43,8 @@ def gdal_cogify(src: Path, dst: Path) -> None:
         "COMPRESS=DEFLATE",
         "-co",
         "TILING_SCHEME=GoogleMapsCompatible",
+        "-co",
+        "BIGTIFF=YES",
         str(src),
         str(dst),
     ]

--- a/geoapi/tasks/raster.py
+++ b/geoapi/tasks/raster.py
@@ -46,7 +46,7 @@ def gdal_cogify(src: Path, dst: Path) -> None:
 
     Reprojects to Web Mercator (EPSG:3857) with GoogleMapsCompatible tiling scheme.
     Uses JPEG for 8-bit RGB/RGBA imagery (lossy, ~10x smaller files).
-    Uses ZSTD for everything else (lossless, preserves pixel values).
+    Uses DEFLATE for everything else (lossless, preserves pixel values).
     """
     heavy_worker_count = 6  # matches --concurrency=6 in geoapi_workers_heavy
     threads_per_worker = max(1, os.cpu_count() // heavy_worker_count)
@@ -72,21 +72,25 @@ def gdal_cogify(src: Path, dst: Path) -> None:
 
     if is_8bit_rgb_or_rgba(src):
         # 8-bit RGB/RGBA imagery (orthomosaics, aerial photos).
-        # So lossy JPG compression is okay and then we save lots of space
+        # So lossy JPG compression is okay and then we save lots of space.
         # Alpha band handled by GDAL.
         compression = ["-co", "COMPRESS=JPEG", "-co", "QUALITY=85"]
     else:
         # Everything else (DEMs, multi-band, 16-bit, float) where pixel
-        # values matter. ZSTD level 3 with predictor gives good compression
-        # ratio and fast decompression. PREDICTOR=YES lets GDAL auto-select
-        # horizontal (int) or floating point (float32) predictor.
+        # values matter. DEFLATE with PREDICTOR=YES gives good lossless
+        # compression; PREDICTOR=YES lets GDAL auto-select horizontal
+        # (int) or floating-point (float32) predictor.
+        #
+        # Note: ZSTD level 3 + PREDICTOR=YES benchmarks slightly better
+        # (smaller files, faster decompression), but QGIS 3.44+ on macOS
+        # ships libtiff without the ZSTD codec due to a regression. So
+        # using DEFLATE but can switch to ZSTD at some later time
+        # See: https://github.com/qgis/QGIS/issues/65409
         compression = [
             "-co",
-            "COMPRESS=ZSTD",
+            "COMPRESS=DEFLATE",
             "-co",
             "PREDICTOR=YES",
-            "-co",
-            "LEVEL=3",
         ]
 
     cmd = base_cmd + compression + [str(src), str(dst)]

--- a/geoapi/tasks/raster.py
+++ b/geoapi/tasks/raster.py
@@ -41,7 +41,11 @@ def gdal_cogify(src: Path, dst: Path) -> None:
         "-t_srs",
         "EPSG:3857",  # Web Mercator
         "-co",
-        "COMPRESS=DEFLATE",
+        "COMPRESS=ZSTD",
+        "-co",
+        "PREDICTOR=YES",
+        "-co",
+        "LEVEL=3",
         "-co",
         "TILING_SCHEME=GoogleMapsCompatible",
         "-co",

--- a/geoapi/tasks/raster.py
+++ b/geoapi/tasks/raster.py
@@ -33,6 +33,11 @@ def _validate_raster_name(name: str) -> None:
 
 def gdal_cogify(src: Path, dst: Path) -> None:
     """Convert to COG"""
+
+    # Determine how many threads to use
+    heavy_worker_count = 6  # i.e. --concurrency=6 in geoapi_workers_heavy
+    threads_per_worker = max(1, os.cpu_count() // heavy_worker_count)
+
     # When creating cog, we convert to Web Mercator and use GoogleMapsCompatible
     cmd = [
         "gdalwarp",
@@ -40,16 +45,18 @@ def gdal_cogify(src: Path, dst: Path) -> None:
         "COG",
         "-t_srs",
         "EPSG:3857",  # Web Mercator
-        "-co",
-        "COMPRESS=ZSTD",
-        "-co",
-        "PREDICTOR=YES",
-        "-co",
-        "LEVEL=3",
-        "-co",
         "TILING_SCHEME=GoogleMapsCompatible",
         "-co",
         "BIGTIFF=YES",
+        # Parallelize warping across multiple threads. COG finalization
+        # (tiling + overviews) is still single-threaded.
+        "-multi",
+        "-wo", f"NUM_THREADS={threads_per_worker}",
+        # Compression: ZSTD level 3 with predictor gives good ratio and fast reads.
+        # PREDICTOR=YES lets GDAL auto-select horizontal (int) or floating point (float32).
+        "-co", "COMPRESS=ZSTD",
+        "-co", "PREDICTOR=YES",
+        "-co", "LEVEL=3",
         str(src),
         str(dst),
     ]

--- a/geoapi/tasks/raster.py
+++ b/geoapi/tasks/raster.py
@@ -43,59 +43,51 @@ def is_8bit_rgb_or_rgba(src: Path) -> bool:
 
 
 def gdal_cogify(src: Path, dst: Path) -> None:
-    """Convert to COG"""
+    """Convert a raster to a Cloud-Optimized GeoTIFF (COG).
 
-    # Determine how many threads to use
-    heavy_worker_count = 6  # i.e. --concurrency=6 in geoapi_workers_heavy
+    Reprojects to Web Mercator (EPSG:3857) with GoogleMapsCompatible tiling scheme.
+    Uses JPEG for 8-bit RGB/RGBA imagery (lossy, ~10x smaller files).
+    Uses ZSTD for everything else (lossless, preserves pixel values).
+    """
+    heavy_worker_count = 6  # matches --concurrency=6 in geoapi_workers_heavy
     threads_per_worker = max(1, os.cpu_count() // heavy_worker_count)
 
-    # When creating cog, we convert to Web Mercator and use GoogleMapsCompatible
-    cmd = [
+    base_cmd = [
         "gdalwarp",
-        "-of",
-        "COG",
-        "-t_srs",
-        "EPSG:3857",  # Web Mercator
-        "TILING_SCHEME=GoogleMapsCompatible",
-        "-co",
-        "BIGTIFF=YES",
+        "-of", "COG",
+        "-t_srs", "EPSG:3857",
+        "-co", "TILING_SCHEME=GoogleMapsCompatible",
+        "-co", "BIGTIFF=YES",
+        "-co", "STATISTICS=YES",
         # Parallelize warping across multiple threads. COG finalization
         # (tiling + overviews) is still single-threaded.
         "-multi",
         "-wo", f"NUM_THREADS={threads_per_worker}",
-        # Compression: ZSTD level 3 with predictor gives good ratio and fast reads.
-        # PREDICTOR=YES lets GDAL auto-select horizontal (int) or floating point (float32).
-        "-co", "COMPRESS=ZSTD",
-        "-co", "PREDICTOR=YES",
-        "-co", "LEVEL=3",
-        str(src),
-        str(dst),
     ]
 
     if is_8bit_rgb_or_rgba(src):
         # 8-bit RGB/RGBA imagery (orthomosaics, aerial photos).
-        # So we use JPEG compression
+        # So lossy JPG compression is okay and then we save lots of space
+        # Alpha band handled by GDAL.
         compression = ["-co", "COMPRESS=JPEG", "-co", "QUALITY=85"]
     else:
-        # Everytyhing lese (like DEMs, multi-band, 16-bit, float) we
-        # use a lossless compression as pixel values matter. ZSTD is
-        # lossless with fast decompression..
+        # Everything else (DEMs, multi-band, 16-bit, float) where pixel
+        # values matter. ZSTD level 3 with predictor gives good compression
+        # ratio and fast decompression. PREDICTOR=YES lets GDAL auto-select
+        # horizontal (int) or floating point (float32) predictor.
         compression = [
             "-co", "COMPRESS=ZSTD",
             "-co", "PREDICTOR=YES",
             "-co", "LEVEL=3",
         ]
 
-    cmd = cmd + compression + [str(src), str(dst)]
+    cmd = base_cmd + compression + [str(src), str(dst)]
 
-    logger.info(f"Converting to cog by running command: {' '.join(cmd)}")
+    logger.info(f"Converting to COG: {' '.join(cmd)}")
 
-    # GDAL creates temp files in the current working directory during COG conversion,
-    # so we run it from the destination directory where Celery has write permissions.
-    working_directory = dst.parent
-
-    subprocess.run(cmd, check=True, cwd=working_directory)
-
+    # GDAL creates temp files in the current working directory during COG
+    # conversion, so we run from the destination directory.
+    subprocess.run(cmd, check=True, cwd=dst.parent)
 
 def get_cog_metadata(path: Path) -> dict:
     """

--- a/geoapi/tasks/raster.py
+++ b/geoapi/tasks/raster.py
@@ -33,8 +33,7 @@ def _validate_raster_name(name: str) -> None:
 
 def is_8bit_rgb_or_rgba(src: Path) -> bool:
     result = subprocess.run(
-        ["gdalinfo", "-json", str(src)],
-        capture_output=True, text=True
+        ["gdalinfo", "-json", str(src)], capture_output=True, text=True
     )
     info = json.loads(result.stdout)
     dtype = info["bands"][0]["type"]
@@ -54,15 +53,21 @@ def gdal_cogify(src: Path, dst: Path) -> None:
 
     base_cmd = [
         "gdalwarp",
-        "-of", "COG",
-        "-t_srs", "EPSG:3857",
-        "-co", "TILING_SCHEME=GoogleMapsCompatible",
-        "-co", "BIGTIFF=YES",
-        "-co", "STATISTICS=YES",
+        "-of",
+        "COG",
+        "-t_srs",
+        "EPSG:3857",
+        "-co",
+        "TILING_SCHEME=GoogleMapsCompatible",
+        "-co",
+        "BIGTIFF=YES",
+        "-co",
+        "STATISTICS=YES",
         # Parallelize warping across multiple threads. COG finalization
         # (tiling + overviews) is still single-threaded.
         "-multi",
-        "-wo", f"NUM_THREADS={threads_per_worker}",
+        "-wo",
+        f"NUM_THREADS={threads_per_worker}",
     ]
 
     if is_8bit_rgb_or_rgba(src):
@@ -76,9 +81,12 @@ def gdal_cogify(src: Path, dst: Path) -> None:
         # ratio and fast decompression. PREDICTOR=YES lets GDAL auto-select
         # horizontal (int) or floating point (float32) predictor.
         compression = [
-            "-co", "COMPRESS=ZSTD",
-            "-co", "PREDICTOR=YES",
-            "-co", "LEVEL=3",
+            "-co",
+            "COMPRESS=ZSTD",
+            "-co",
+            "PREDICTOR=YES",
+            "-co",
+            "LEVEL=3",
         ]
 
     cmd = base_cmd + compression + [str(src), str(dst)]
@@ -88,6 +96,7 @@ def gdal_cogify(src: Path, dst: Path) -> None:
     # GDAL creates temp files in the current working directory during COG
     # conversion, so we run from the destination directory.
     subprocess.run(cmd, check=True, cwd=dst.parent)
+
 
 def get_cog_metadata(path: Path) -> dict:
     """

--- a/geoapi/tasks/raster.py
+++ b/geoapi/tasks/raster.py
@@ -4,6 +4,7 @@ import subprocess
 import math
 from pathlib import Path
 from uuid import uuid4
+from sqlalchemy import func
 
 from geoapi.utils.assets import (
     make_project_asset_dir,
@@ -213,6 +214,14 @@ def import_tile_servers_from_tapis(
             # only prepopulated for single banded images)
             render_options = tile_options.pop("renderOptions", {})
 
+            # Find current max zindex for existing TilserServers
+            max_z = (
+                session.query(func.max(TileServer.uiOptions["zIndex"].as_integer()))
+                .filter(TileServer.project_id == project_id)
+                .scalar()
+            )
+            new_z_index = (max_z + 1) if max_z is not None else 0
+
             # Create TileServer pointing to TiTiler
             ts = TileServer(
                 project_id=project_id,
@@ -229,7 +238,7 @@ def import_tile_servers_from_tapis(
                 current_path=tapis_file.path,
                 tileOptions=tile_options,
                 uiOptions={
-                    "zIndex": 0,  # frontend will readjust as needed
+                    "zIndex": new_z_index,  # frontend will readjust as needed
                     "opacity": 1,
                     "isActive": True,
                     "showInput": False,

--- a/geoapi/tests/tasks_tests/test_raster.py
+++ b/geoapi/tests/tasks_tests/test_raster.py
@@ -113,7 +113,8 @@ def test_import_tile_server_singleband_success(
     cog_path = Path(tile_server.url)
     result = subprocess.run(
         ["gdalinfo", "-json", str(cog_path)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     info = json.loads(result.stdout)
     assert info["metadata"]["IMAGE_STRUCTURE"]["COMPRESSION"] == "ZSTD"
@@ -159,7 +160,8 @@ def test_import_tile_server_rgb_success(
     cog_path = Path(tile_server.url)
     result = subprocess.run(
         ["gdalinfo", "-json", str(cog_path)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     info = json.loads(result.stdout)
     assert info["metadata"]["IMAGE_STRUCTURE"]["COMPRESSION"] == "YCbCr JPEG"

--- a/geoapi/tests/tasks_tests/test_raster.py
+++ b/geoapi/tests/tasks_tests/test_raster.py
@@ -1,9 +1,12 @@
 import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
+import json
+import subprocess
 
 from geoapi.tasks.raster import (
     _validate_raster_name,
+    is_8bit_rgb_or_rgba,
     import_tile_servers_from_tapis,
 )
 from geoapi.models import TileServer, TaskStatus
@@ -31,6 +34,14 @@ def test_validate_invalid_extension():
 
     with pytest.raises(ValueError, match="Unsupported raster extension"):
         _validate_raster_name("test.png")
+
+
+def test_is_8bit_rgb_or_rgba_true(raster_threeband_byte_rgbsmall):
+    assert is_8bit_rgb_or_rgba(Path(raster_threeband_byte_rgbsmall.name)) is True
+
+
+def test_is_8bit_rgb_or_rgba_false_singleband(raster_singleband_int16_m30dem):
+    assert is_8bit_rgb_or_rgba(Path(raster_singleband_int16_m30dem.name)) is False
 
 
 @pytest.mark.worker
@@ -98,6 +109,15 @@ def test_import_tile_server_singleband_success(
     cog_path = Path(tile_server.url)
     assert cog_path.exists()
 
+    # Check if output file is correct (e.g. correct compression)
+    cog_path = Path(tile_server.url)
+    result = subprocess.run(
+        ["gdalinfo", "-json", str(cog_path)],
+        capture_output=True, text=True,
+    )
+    info = json.loads(result.stdout)
+    assert info["metadata"]["IMAGE_STRUCTURE"]["COMPRESSION"] == "ZSTD"
+
 
 @pytest.mark.worker
 @patch("geoapi.tasks.raster.TapisUtils")
@@ -134,6 +154,15 @@ def test_import_tile_server_rgb_success(
 
     db_session.refresh(task_fixture)
     assert task_fixture.status == TaskStatus.COMPLETED
+
+    # Check if output file is correct (e.g. correct compression)
+    cog_path = Path(tile_server.url)
+    result = subprocess.run(
+        ["gdalinfo", "-json", str(cog_path)],
+        capture_output=True, text=True,
+    )
+    info = json.loads(result.stdout)
+    assert info["metadata"]["IMAGE_STRUCTURE"]["COMPRESSION"] == "YCbCr JPEG"
 
 
 @pytest.mark.worker

--- a/geoapi/tests/tasks_tests/test_raster.py
+++ b/geoapi/tests/tasks_tests/test_raster.py
@@ -36,10 +36,12 @@ def test_validate_invalid_extension():
         _validate_raster_name("test.png")
 
 
+@pytest.mark.worker
 def test_is_8bit_rgb_or_rgba_true(raster_threeband_byte_rgbsmall):
     assert is_8bit_rgb_or_rgba(Path(raster_threeband_byte_rgbsmall.name)) is True
 
 
+@pytest.mark.worker
 def test_is_8bit_rgb_or_rgba_false_singleband(raster_singleband_int16_m30dem):
     assert is_8bit_rgb_or_rgba(Path(raster_singleband_int16_m30dem.name)) is False
 

--- a/geoapi/tests/tasks_tests/test_raster.py
+++ b/geoapi/tests/tasks_tests/test_raster.py
@@ -119,7 +119,7 @@ def test_import_tile_server_singleband_success(
         text=True,
     )
     info = json.loads(result.stdout)
-    assert info["metadata"]["IMAGE_STRUCTURE"]["COMPRESSION"] == "ZSTD"
+    assert info["metadata"]["IMAGE_STRUCTURE"]["COMPRESSION"] == "DEFLATE"
 
 
 @pytest.mark.worker


### PR DESCRIPTION
## Overview: ##

Fix crashes when importing large GeoTIFF orthomosaics (e.g. Eaton Fire PRJ-5815) into the
`heavy` Celery worker, and rework COG creation to use compression appropriate for the data type.

Previously, all COGs used DEFLATE compression. This PR introduces two compression paths:
- **8-bit RGB/RGBA imagery** (orthomosaics) → JPEG Q85 (~10x smaller files)
- **Everything else** (DEMs, multi-band, float) → DEFLATE 

Note: Benchmarks showed ZSTD level 3 + predictor is the better choice (lossless, ~15% smaller than DEFLATE, and faster to decompress). However, QGIS 3.44.x on macOS (and likely 4.0.x/4.1.x) ships libtiff without the ZSTD codec. https://github.com/qgis/QGIS/issues/65409.  So using DEFALTE. 

I've also added a follow-on Jira issue for TiTiler caching and performance:
https://tacc-main.atlassian.net/browse/WG-648

## Related Jira tickets: ##

* [WG-642](https://tacc-main.atlassian.net/browse/WG-642)

## Summary of Changes: ##

1. **Reduce Celery prefetch multiplier from 4 (default) to 1** — With the default prefetch of 4, the heavy worker (concurrency=6) could pull up to 24 extra messages from RabbitMQ. These sit unacked while waiting for a free worker slot, and RabbitMQ's 30-minute `consumer_timeout` kills the AMQP channel if they aren't acked in time — crashing the entire worker process. Setting it to 1 minimizes how many messages sit unacked.

2. **Add BIGTIFF=YES to gdalwarp** — Large geotiffs were producing COGs that exceed the classic TIFF 4GB file size limit. Adding `BIGTIFF=YES` fixes that.

3. **Increase RabbitMQ consumer_timeout to 5 hours** — Increase consumer_timeout from 30 min to 5 hours  (to handle long times for raster conversions)  (**Note**: Will core-portal-deployment change).

4. **Branch COG compression by data type** — 8-bit RGB/RGBA imagery uses JPEG Q85 (lossy,~1.4 GB vs 18 GB for a 10cm orthomosaic). All other rasters use ZSTD level 3 with PREDICTOR=YES (lossless, ~15 GB vs 18 GB DEFLATE for a DEM). Also adds STATISTICS=YES to embed band stats in the COG header.

## Testing Steps: ##

Can test locally but it takes a long time to download the images to your local geoapi:

1. Import a published dataset with large orthomosaics (e.g. PRJ-5815 Eaton Fire or Palisades Fire imagery)
2. Verify all COGs are created successfully and no confirm no worker crashes in Celery logs

Deployed to `staging` for testing there. And I have 2 staging maps pre-loaded.

## Notes: ##

- [x] [PR](https://github.com/TACC/Core-Portal-Deployments/pull/168) to update `consumer_timeout` for `core-portal-deployment` repo 

## Eaton Fire Orthomosaic (8-bit RGBA, 64000×128768, 10cm resolution)

| Compression              | File Size | Creation Time |
|--------------------------|-----------|---------------|
| Original source (not COG)| 9.7 GB    | —             |
| JPEG Q85                 | 1.4 GB    | 36:39         |
| ZSTD level 3 + predictor | 14 GB     | 42:17         |
| DEFLATE (default)        | 18 GB     | 52:25         |
| uncompressed | 42 GB     | 36:14         |

### Tile read speed (TiTiler, 5 runs avg)

| Compression              | Avg Read | Min Read |
|--------------------------|----------|----------|
| uncompressed      | 0.106s   | 0.039s   |
| JPEG Q85                 | 0.115s   | 0.090s   |
| ZSTD level 3 + predictor | 0.133s   | 0.055s   |
| DEFLATE (default)        | 0.139s   | 0.095s   |

---

## Carolinas DEM (Float32, 96000×73400, 5m resolution)

https://www.designsafe-ci.org/data/browser/public/designsafe.storage.published/PRJ-5758/%2Fpublished-data%2FPRJ-5758%2FProject--topobathymetric-digital-elevation-models-dem-for-flood-modeling-in-the-carolinas--V2%2Fdata%2FGeoTIF%20Files?doi=10.17603/ds2-mzc8-s589

| Compression              | File Size | Creation Time |
|--------------------------|-----------|---------------|
| Original source (not COG)| 9.5 GB    | —             |
| ZSTD level 3 + predictor | 15 GB     | ~28 min       |
| ZSTD level 9 + predictor | 15 GB     | ~38 min       |
| DEFLATE level 6 + pred   | 16 GB     | ~40 min       |
| LZW + predictor          | 20 GB     | ~34 min       |
| LERC_ZSTD (lossless)     | 21 GB     | —             |


Resources:

* COG
  * https://github.com/geostandards-ch/cog-best-practices#lossless-raster
  * https://blog.cleverelephant.ca/2015/02/geotiff-compression-for-dummies.html
  * https://kokoalberti.com/articles/geotiff-compression-optimization-guide/
* TITILER
  * https://developmentseed.org/titiler/advanced/performance_tuning/#setting-a-config-variable



