### PR TITLE
task/WG-655: improve install of pdal in worker image

### DIFF
--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
     ffmpeg \
     curl \
     git \
+    vim \
     && rm -rf /var/lib/apt/lists/*
 
 # https://python-poetry.org/docs/configuration/#using-environment-variables

--- a/devops/Dockerfile.worker
+++ b/devops/Dockerfile.worker
@@ -1,3 +1,18 @@
+# Build a minimal PDAL environment using conda-forge.
+# We only need the pdal binary and its C++ shared libs.
+# The final image will copy just this env. So we strip
+# everything else (static libs, headers, docs, Python) to
+# reduce image size.
+FROM condaforge/miniforge3:latest AS pdal-builder
+RUN conda create -n pdal -c conda-forge --no-default-packages pdal -y \
+    && conda clean -afy \
+    && find /opt/conda/envs/pdal -name '*.a' -delete \
+    && rm -rf /opt/conda/envs/pdal/share/doc \
+             /opt/conda/envs/pdal/share/man \
+             /opt/conda/envs/pdal/include \
+             /opt/conda/envs/pdal/bin/python* \
+             /opt/conda/envs/pdal/lib/python*
+
 FROM python:3.12-slim AS python-base
 
 LABEL maintainer="DesignSafe-CI <designsafe-ci@tacc.utexas.edu>"
@@ -9,6 +24,7 @@ RUN apt-get update && apt-get install -y \
     libtiff-dev \
     libgeotiff-dev \
     libgdal-dev \
+    gdal-bin \
     libboost-system-dev \
     libboost-thread-dev \
     libboost-filesystem-dev \
@@ -48,19 +64,14 @@ RUN sed -i '/<body>/r /tmp/nsf_logo_snippet.txt' /opt/PotreeConverter/build/reso
 #  - remove reference to background image
 RUN sed -i 's/style="[^"]*background-image:[^"]*"//' /opt/PotreeConverter/build/resources/page_template/viewer_template.html
 
-# Install Miniforge for our Python environment (provides easier PDAL installation)
-RUN wget -q -O miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-$(uname -m).sh \
-    && sh miniforge.sh -b -p /opt/conda \
-    && rm miniforge.sh
+# Copy PDAL from miniforge builder (no conda runtime needed)
+COPY --from=pdal-builder /opt/conda/envs/pdal /opt/pdal
 
-ENV PATH="/opt/conda/bin:${PATH}"
-
-# Create a conda environment with Python 3.12 and activate it
-RUN conda create -n py312env python=3.12 -y
-SHELL ["conda", "run", "-n", "py312env", "/bin/bash", "-c"]
-
-# Install PDAL using conda
-RUN conda install -c conda-forge pdal -y
+# Wrapper that sets LD_LIBRARY_PATH only for pdal,
+# so conda's GDAL never leaks into Python processes
+RUN echo '#!/bin/sh' > /usr/local/bin/pdal \
+    && echo 'LD_LIBRARY_PATH="/opt/pdal/lib" exec /opt/pdal/bin/pdal "$@"' >> /usr/local/bin/pdal \
+    && chmod +x /usr/local/bin/pdal
 
 # https://python-poetry.org/docs/configuration/#using-environment-variables
 ENV POETRY_VERSION=2.1 \
@@ -84,25 +95,6 @@ COPY devops/poetry.lock devops/pyproject.toml ./
 # install runtime deps - uses $POETRY_VIRTUALENVS_IN_PROJECT internally
 RUN poetry install
 
-# Create an entrypoint script that activates our conda environment
-RUN echo '#!/bin/bash' > /usr/local/bin/entrypoint.sh && \
-    echo 'set -e' >> /usr/local/bin/entrypoint.sh && \
-    echo '' >> /usr/local/bin/entrypoint.sh && \
-    echo '# Activate conda and the specific environment' >> /usr/local/bin/entrypoint.sh && \
-    echo '. /opt/conda/etc/profile.d/conda.sh' >> /usr/local/bin/entrypoint.sh && \
-    echo 'conda activate py312env' >> /usr/local/bin/entrypoint.sh && \
-    echo '' >> /usr/local/bin/entrypoint.sh && \
-    echo '# Execute the passed command' >> /usr/local/bin/entrypoint.sh && \
-    echo 'exec "$@"' >> /usr/local/bin/entrypoint.sh && \
-    chmod +x /usr/local/bin/entrypoint.sh
-
-# Set the entrypoint
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-
-# activate conda (to handle when user starts a bash via docker exec)
-RUN echo '. /opt/conda/etc/profile.d/conda.sh' >> /root/.bashrc && \
-    echo 'conda activate py312env' >> /root/.bashrc
-
 RUN groupadd -g 1100 celeryuser
 RUN useradd -s /sbin/nologin -u 1100 -g 1100 celeryuser
 RUN mkdir -p /var/run/celery && chown -R 1100:1100 /var/run/celery
@@ -113,10 +105,6 @@ CMD ["bash"]
 ##############
 # `development` image target is used for local development
 FROM python-base AS development
-
-# copy in our built poetry + venv
-COPY --from=python-base $POETRY_HOME $POETRY_HOME
-COPY --from=python-base $PYSETUP_PATH $PYSETUP_PATH
 
 # Install dev dependencies
 RUN poetry install --with dev

--- a/devops/Dockerfile.worker
+++ b/devops/Dockerfile.worker
@@ -119,9 +119,7 @@ WORKDIR /app/geoapi
 # `production` image target is used for deployed runtime environments
 FROM python-base AS production
 
-# Install runtime dependencies
-COPY --from=python-base $PYSETUP_PATH $PYSETUP_PATH
-
+# Inherits runtime deps from python-base; just add app code
 COPY geoapi /app/geoapi
 
 ENV PYTHONPATH=/app

--- a/devops/Dockerfile.worker
+++ b/devops/Dockerfile.worker
@@ -67,8 +67,8 @@ RUN sed -i 's/style="[^"]*background-image:[^"]*"//' /opt/PotreeConverter/build/
 # Copy PDAL from miniforge builder (no conda runtime needed)
 COPY --from=pdal-builder /opt/conda/envs/pdal /opt/pdal
 
-# Wrapper that sets LD_LIBRARY_PATH only for pdal,
-# so conda's GDAL never leaks into Python processes
+# Wrapper that sets LD_LIBRARY_PATH for just pdal so it uses its included libraries (like gdal
+# which differ from our base image's gdal)
 RUN echo '#!/bin/sh' > /usr/local/bin/pdal \
     && echo 'LD_LIBRARY_PATH="/opt/pdal/lib" exec /opt/pdal/bin/pdal "$@"' >> /usr/local/bin/pdal \
     && chmod +x /usr/local/bin/pdal

--- a/devops/Dockerfile.worker
+++ b/devops/Dockerfile.worker
@@ -1,8 +1,4 @@
-# Build a minimal PDAL environment using conda-forge.
-# We only need the pdal binary and its C++ shared libs.
-# The final image will copy just this env. So we strip
-# everything else (static libs, headers, docs, Python) to
-# reduce image size.
+# Get only pdal binary (and required libs) from conda
 FROM condaforge/miniforge3:latest AS pdal-builder
 RUN conda create -n pdal -c conda-forge --no-default-packages pdal -y \
     && conda clean -afy \
@@ -64,7 +60,7 @@ RUN sed -i '/<body>/r /tmp/nsf_logo_snippet.txt' /opt/PotreeConverter/build/reso
 #  - remove reference to background image
 RUN sed -i 's/style="[^"]*background-image:[^"]*"//' /opt/PotreeConverter/build/resources/page_template/viewer_template.html
 
-# Copy PDAL from miniforge builder (no conda runtime needed)
+# Copy pdal binary and libs from builder
 COPY --from=pdal-builder /opt/conda/envs/pdal /opt/pdal
 
 # Wrapper that sets LD_LIBRARY_PATH for just pdal so it uses its included libraries (like gdal

--- a/geoapi/tests/utils_tests/test_point_cloud.py
+++ b/geoapi/tests/utils_tests/test_point_cloud.py
@@ -1,6 +1,7 @@
 import pytest
 from geoapi.utils.point_cloud import getProj4, get_bounding_box_2d
 from geoapi.exceptions import InvalidCoordinateReferenceSystem
+from shapely.geometry import Polygon
 
 
 @pytest.mark.worker
@@ -58,9 +59,12 @@ def test_get_bounding_box_medium_size_compressed_laz(
     lidar_medium_size_compressed_las1pt2,
 ):
     bounding_box = get_bounding_box_2d([lidar_medium_size_compressed_las1pt2])
-    assert (
-        str(bounding_box)
-        == "POLYGON ((-105.209138419338 39.66131144844282, -105.20095449180293 39.66131144844282, "
-        "-105.20095449180293 39.66928201079495, -105.209138419338 39.66928201079495,"
-        " -105.209138419338 39.66131144844282))"
+    expected = Polygon(
+        [
+            (-105.2091, 39.6613),
+            (-105.2010, 39.6613),
+            (-105.2010, 39.6693),
+            (-105.2091, 39.6693),
+        ]
     )
+    assert bounding_box.equals_exact(expected, tolerance=1e-3)


### PR DESCRIPTION
## Overview: ##

Previously the worker image installed full conda runtime and activated a conda Python 3.12 environment just to get the pdal CLI. This pulled in unwanted default packages and required an entrypoint script and .bashrc hooks to keep conda activated.

Now PDAL is installed from conda-forge in a separate miniforge build stage and only the pdal binary and shared libs are added to the image. A wrapper script for pdal lets us set LD_LIBRARY_PATH so PDAL's bundled
libs don't conflict with the base image's GDAL.

Also adds gdal-bin (was in our conda but we need for `gdalmerge`) and vim (for debugging) to apt packages.

## Testing Steps: ##
1. Run a point cloud import to confirm PDAL pipeline execution
2. Verify poetry/Python environment is unaffected

## Notes: ##

TODO
- [x] add unit test
- [x] run locally 
- [ ] run on dev
