### PR TITLE
Fix: rework db sessions during refresh token to fix 2 errors seen in logs

### DIFF
--- a/geoapi/routes/auth.py
+++ b/geoapi/routes/auth.py
@@ -192,12 +192,15 @@ class AuthController(Controller):
         if is_anonymous(request.user):
             return Response({"username": None, "authToken": None}, status_code=200)
 
-        tapis = TapisUtils(db_session, request.user)
+        # Merge the user into the current session so refresh_access_token can work
+        user = db_session.merge(request.user)
+
+        tapis = TapisUtils(db_session, user)
 
         try:
             tapis._ensure_valid_token(buffer=60 * 30)  # 30 minutes buffer
         except Exception:
-            logger.exception(f"Error ensuring valid token for user:{request.user}")
+            logger.exception(f"Error ensuring valid token for user:{user}")
             raise NotAuthorizedException("Could not refresh authentication token")
 
         user_info = {

--- a/geoapi/services/users.py
+++ b/geoapi/services/users.py
@@ -232,7 +232,10 @@ class UserService:
                     locked_auth.refresh_token_expires_at = data["refresh_token"][
                         "expires_at"
                     ]
-                    database_session.commit()
+
+                    # write token updates to DB within savepoint
+                    database_session.flush()
+
                     logger.info(
                         f"Finished refreshing token for user:{user.username}"
                         f" tenant:{user.tenant_id}"
@@ -253,6 +256,10 @@ class UserService:
                         f" tenant:{user.tenant_id}: {response}, {response.text}"
                     )
                     raise RefreshTokenError
+
+            # persist token updates after savepoint completes
+            database_session.commit()
+
             # Re-query the updated user after the transaction is committed
             # (so that the caller has the latest state which includes the updated auth token)
             database_session.refresh(user)


### PR DESCRIPTION
## Overview: ##

Fixes two errors (see Notes) that caused token refresh to fail even though the refresh itself succeeded (errors in log despite having valid tokens written to the the DB)

Error 1 (geoapi_backend): The User object from auth middleware was detached from the route's db_session, so database_session.refresh(user) failed. Fix: merge the user into db_session in /auth/user.
Error 2 (geoapi_workers): Calling commit() inside begin_nested() closed the transaction, causing subsequent attribute access to fail. Fix: use flush() inside the block and commit after it exits.

## Related Jira tickets: ##

None

## Testing Steps: ##
1. You could run locally and wait till a token needs to be refreshed.
2. We can place on dev to confirm or just check these errors don't show up after deployed to dev or staging.

## Notes: ##

Error 1:
```

2026-04-21 17:20:26,631 :: INFO :: [users.py:236] :: Finished refreshing token for user:nathanf tenant:designsafe 2026-04-21 17:20:26,633 :: ERROR :: [users.py:260] :: Transaction error during token refresh for user:nathanf: Instance '<User at 0xffff796b7d70>' is not persistent within this Session Traceback (most recent call last): File "/app/geoapi/services/users.py", line 258, in refresh_access_token database_session.refresh(user) File "/opt/pysetup/.venv/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 3147, in refresh self._expire_state(state, attribute_names) File "/opt/pysetup/.venv/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 3273, in _expire_state self._validate_persistent(state) File "/opt/pysetup/.venv/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 4131, in _validate_persistent raise sa_exc.InvalidRequestError( sqlalchemy.exc.InvalidRequestError: Instance '<User at 0xffff796b7d70>' is not persistent within this Session 2026-04-21 17:20:26,641 :: ERROR :: [external_apis.py:162] :: There was a problem refreshing access token of user:nathanf. 2026-04-21 17:20:26,646 :: ERROR :: [jwt_utils.py:147] :: token not valid: Signature has expired 2026-04-21 17:20:26,646 :: ERROR :: [external_apis.py:172] :: Access token of user:nathanf is expired (or invalid). 2026-04-21 17:20:26,646 :: ERROR :: [auth.py:200] :: Error ensuring valid token for user:<User(uname=nathanf, id=1,tenant=designsafe)access_token=gCjmg,access_token_expires_at=2026-04-21 17:02:24.480109+00:00,refresh_token=PPg0A,refresh_token_expires_at=2027-04-21 13:02:24.531550+00:00)> Traceback (most recent call last): File "/app/geoapi/routes/auth.py", line 198, in get_user_info tapis._ensure_valid_token(buffer=60 * 30) # 30 minutes buffer
```


Error 2:

```
[1;34m[2026-04-21 21:25:52,788: DEBUG/ForkPoolWorker-1] user:<User(uname=nathanf, id=1,tenant=designsafe)access_token=XmYvA,access_token_expires_at=2026-04-21 21:20:26.561116+00:00,refresh_token=tMdNg,refresh_token_expires_at=2027-04-21 17:20:26.650597+00:00)>  has a token about to expire or has expired; we will refresh it.[0m
[2026-04-21 21:25:52,788: INFO/ForkPoolWorker-1] Refreshing token for user:nathanf tenant:designsafe
[2026-04-21 21:25:52,819: INFO/ForkPoolWorker-1] Acquired auth for refreshing token for user:nathanf tenant:designsafe
[1;31m[2026-04-21 21:25:53,514: ERROR/ForkPoolWorker-1] Transaction error during token refresh for user:nathanf: Can't operate on closed transaction inside context manager.  Please complete the context manager before emitting further commands.
Traceback (most recent call last):
  File "/app/geoapi/services/users.py", line 237, in refresh_access_token
    f"Finished refreshing token for user:{user.username}"
                                          ^^^^^^^^^^^^^
  File "/opt/pysetup/.venv/lib/python3.12/site-packages/sqlalchemy/orm/attributes.py", line 566, in __get__
    return self.impl.get(state, dict_)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pysetup/.venv/lib/python3.12/site-packages/sqlalchemy/orm/attributes.py", line 1086, in get
    value = self._fire_loader_callables(state, key, passive)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pysetup/.venv/lib/python3.12/site-packages/sqlalchemy/orm/attributes.py", line 1116, in _fire_loader_callables
    return state._load_expired(state, passive)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pysetup/.venv/lib/python3.12/site-packages/sqlalchemy/orm/state.py", line 803, in _load_expired
    self.manager.expired_attribute_loader(self, toload, passive)
  File "/opt/pysetup/.venv/lib/python3.12/site-packages/sqlalchemy/orm/loading.py", line 1670, in load_scalar_attributes
    result = load_on_ident(
             ^^^^^^^^^^^^^^
  File "/opt/pysetup/.venv/lib/python3.12/site-packages/sqlalchemy/orm/loading.py", line 509, in load_on_ident
    return load_on_pk_identity(
           ^^^^^^^^^^^^^^^^^^^^
  File "/opt/pysetup/.venv/lib/python3.12/site-packages/sqlalchemy/orm/loading.py", line 694, in load_on_pk_identity
    session.execute(
  File "/opt/pysetup/.venv/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2365, in execute
    return self._execute_internal(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pysetup/.venv/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2241, in _execute_internal
    conn = self._connection_for_bind(bind)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pysetup/.venv/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2105, in _connection_for_bind
    TransactionalContext._trans_ctx_check(self)
  File "/opt/pysetup/.venv/lib/python3.12/site-packages/sqlalchemy/engine/util.py", line 111, in _trans_ctx_check
    raise exc.InvalidRequestError(
sqlalchemy.exc.InvalidRequestError: Can't operate on closed transaction inside context manager.  Please complete the context manager before emitting further commands.[0m
[1;31m[2026-04-21 21:25:53,540: ERROR/ForkPoolWorker-1] There was a problem refreshing access token of user:nathanf.[0m
[1;31m[2026-04-21 21:25:53,909: ERROR/ForkPoolWorker-1] Unhandled exception when updating users for project:52. Performing rollback of current database transaction
Traceback (most recent call last):
  File "/app/geoapi/tasks/external_data.py", line 553, in refresh_projects_watch_users
    get_system_users(session, importing_user, project.system_id)
  File "/app/geoapi/utils/external_apis.py", line 388, in get_system_users
    return custom_system_user_retrieval[user.tenant_id.upper()](
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/geoapi/custom/designsafe/project_users.py", line 30, in get_system_users
    project = get_designsafe_project_data(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/geoapi/custom/designsafe/utils.py", line 38, in get_designsafe_project_data
    resp.raise_for_status()
  File "/opt/pysetup/.venv/lib/python3.12/site-packages/requests/models.py", line 1026, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: [https://pprd.designsafe-ci.org/api/projects/v2/78ed9d60-1c75-44b4-98ab-9b90c7416a53/[0m](https://pprd.designsafe-ci.org/api/projects/v2/78ed9d60-1c75-44b4-98ab-9b90c7416a53/%1B%5B0m)
```
