### PR TITLE
Strip build-time Python tooling from production image

### DIFF
--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -64,8 +64,11 @@ WORKDIR /app/geoapi
 # `production` image target is used for deployed runtime environments
 FROM python-base AS production
 
-# Install runtime dependencies
-COPY --from=python-base $PYSETUP_PATH $PYSETUP_PATH
+# Strip build-time tooling (Poetry + bundled pip/virtualenv/dulwich) and bump venv pip
+RUN "$VENV_PATH/bin/pip" install --no-cache-dir --upgrade pip \
+    && rm -rf "$POETRY_HOME" \
+              /root/.local/share/virtualenv \
+              /root/.cache
 
 COPY geoapi /app/geoapi
 

--- a/devops/Dockerfile.worker
+++ b/devops/Dockerfile.worker
@@ -119,7 +119,12 @@ USER 1100:1100
 # `production` image target is used for deployed runtime environments
 FROM python-base AS production
 
-# Inherits runtime deps from python-base; just add app code
+# Strip build-time tooling (Poetry + bundled pip/virtualenv/dulwich) and bump venv pip
+RUN "$VENV_PATH/bin/pip" install --no-cache-dir --upgrade pip \
+    && rm -rf "$POETRY_HOME" \
+              /root/.local/share/virtualenv \
+              /root/.cache
+
 COPY geoapi /app/geoapi
 
 ENV PYTHONPATH=/app

--- a/devops/Dockerfile.worker
+++ b/devops/Dockerfile.worker
@@ -101,6 +101,20 @@ RUN mkdir -p /var/run/celery && chown -R 1100:1100 /var/run/celery
 # Set a default command (can be overridden by docker-compose)
 CMD ["bash"]
 
+# Patch bundled jquery-ui 1.12.1 -> 1.13.2 in the Potree viewer template to clear
+# CVE-2021-41182/41183/41184 + CVE-2022-31160. Both template paths are flagged.
+# See https://tacc-main.atlassian.net/browse/WG-38
+RUN JQUERY_UI_VERSION=1.13.2 \
+    && wget -qO /tmp/jquery-ui.min.js  "https://code.jquery.com/ui/${JQUERY_UI_VERSION}/jquery-ui.min.js" \
+    && wget -qO /tmp/jquery-ui.min.css "https://code.jquery.com/ui/${JQUERY_UI_VERSION}/themes/base/jquery-ui.min.css" \
+    && for d in /opt/PotreeConverter/build/resources/page_template/libs/jquery-ui \
+                /opt/PotreeConverter/resources/page_template/libs/jquery-ui; do \
+           cp /tmp/jquery-ui.min.js  "$d/jquery-ui.min.js"; \
+           cp /tmp/jquery-ui.min.css "$d/jquery-ui.min.css"; \
+           sed -i "s/\"version\": \"1.12.1\"/\"version\": \"${JQUERY_UI_VERSION}\"/" "$d/package.json"; \
+       done \
+    && rm -f /tmp/jquery-ui.min.js /tmp/jquery-ui.min.css
+
 ##############
 # `development` image target is used for local development
 FROM python-base AS development

--- a/devops/README.md
+++ b/devops/README.md
@@ -55,4 +55,14 @@ poetry update
 ```
 
 Poetry edits `/devops/pyproject.toml` and `/devops/poetry.lock` in place; the
-mount writes them back to the host. 
+mount writes them back to the host.
+
+### Scanning image
+
+Build the production images and then scan
+
+```
+make build
+trivy image --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL taccwma/geoapi:latest
+trivy image --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL taccwma/geoapi-workers:latest
+```


### PR DESCRIPTION
## Overview: ##

This fixes some CVEs in image scans:

* Poetry and its bundled pip/virtualenv live in the runtime image but aren't used at runtime, and were flagging CVEs in image scans (RT #40702). Remove $POETRY_HOME and upgrade the app venv's pip
* Bump bundled jquery-ui to 1.13.2 in Potree viewer template](https://github.com/TACC-Cloud/geoapi/pull/289/commits/73a728e3966d0d95de4430f7b1a52e741371affb)

Added a note about the viewer to https://tacc-main.atlassian.net/browse/WG-38

## Related Jira tickets: ##

None
