### PR TITLE
Task/improve logging and litestar warnings

### DIFF
--- a/geoapi/db.py
+++ b/geoapi/db.py
@@ -50,7 +50,7 @@ def get_celery_engine():
     """
     global _celery_engine
     if _celery_engine is None:
-        logger.info("Creating shared Celery database engine")
+        logger.debug("Creating shared Celery database engine")
         _celery_engine = create_engine(
             get_db_connection_string(settings, app_name="geoapi_celery"),
             echo=False,

--- a/geoapi/utils/jwt_utils.py
+++ b/geoapi/utils/jwt_utils.py
@@ -142,9 +142,12 @@ def is_token_valid(token: str) -> bool:
         # Decode the token and automatically validate the exp claim
         decode_token(token)
         return True  # Token is valid and not expired
-    except (jwt.ExpiredSignatureError, jwt.InvalidTokenError) as e:
+    except jwt.ExpiredSignatureError:
+        logger.debug("token expired")
+        return False
+    except jwt.InvalidTokenError as e:
         logger.error(f"token not valid: {e}")
-        return False  # Token is expired or invalid
+        return False
 
 
 def create_token_expiry_hours_from_now(token: str, hours_from_now: int = 4) -> str:

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,7 @@ markers =
     worker: tests that require geoapi worker
 # defaults options sets to be not worker
 addopts = -m "not worker"
+
+# Remove after https://tacc-main.atlassian.net/browse/WG-694
+filterwarnings =
+    ignore::litestar.utils.deprecation.LitestarDeprecationWarning


### PR DESCRIPTION
## Overview: ##

This PR makes some minor changes to logging:
- Lower log level for expired JWT tokens from `error` to `debug` (expected during token refresh cycles)
- Lower log level for Celery DB engine creation from `error` to appropriate level
- Suppress Litestar 2.x deprecation warnings in `pytest.ini` (tracked in WG-694)


## Related Jira tickets: ##

None
