### PR TITLE
task/WG-703: fix shapefile import failing on NaN values in shapefile properties 

### DIFF
--- a/geoapi/services/vectors.py
+++ b/geoapi/services/vectors.py
@@ -1,4 +1,5 @@
 import geopandas as gpd
+import pandas as pd
 from geoapi.log import logging
 from typing import List, IO
 import tempfile
@@ -58,6 +59,8 @@ class VectorService:
             shapefile = shapefile.to_crs(epsg=4326)
             for index, row in shapefile.iterrows():
                 properties = {
-                    key: value for key, value in row.items() if key != "geometry"
+                    key: (None if pd.isna(value) else value)
+                    for key, value in row.items()
+                    if key != "geometry"
                 }
                 yield row["geometry"], properties


### PR DESCRIPTION
## Overview: ##

Fixes shapefile import failures caused by NaN values in DBF fields being serialized as invalid JSON.

## Related Jira tickets: ##

* [WG-702](https://tacc-main.atlassian.net/browse/WG-702)

## Summary of Changes: ##
- In `VectorService.process_shapefile`, convert NaN/NaT/None values (via `pd.isna`) to `None` when building feature properties, so they serialize as valid JSON `null` instead of invalid `NaN`.

## Testing Steps: ##
1. Import a shapefile with missing/null numeric fields (e.g. `austin_watersheds` in https://www.designsafe-ci.org/data/browser/projects/PRJ-4185/workdir/%2Fshapefile_good%2Faustin_watersheds) and confirm it imports.

## Notes: ##

This fixes current work which will be replaced shorting by the work-in-progress https://github.com/TACC-Cloud/geoapi/pull/294